### PR TITLE
Hint the use of a macro for fw version number

### DIFF
--- a/docs/others/cpp-api-reference.md
+++ b/docs/others/cpp-api-reference.md
@@ -27,7 +27,10 @@ void Homie_setFirmware(const char* name, const char* version);
 // This is not a typo
 ```
 
-Set the name and version of the firmware. This is useful for OTA, as Homie will check against the server if there is a newer version.
+Set the name and version of the firmware.
+This is useful for OTA, as Homie will check against the server if there is a newer version.
+Be aware, that the function is implemented as a `define` macro.
+If you want to define the name or version outside the function call, you need to do so in the form of a `define` as well. 
 
 !!! warning "Mandatory!"
     You need to set the firmware for your sketch to work.

--- a/examples/LightOnOff/LightOnOff.ino
+++ b/examples/LightOnOff/LightOnOff.ino
@@ -1,5 +1,6 @@
 #include <Homie.h>
 
+#define firmwareVersion "1.0.0";
 const int PIN_RELAY = 5;
 
 HomieNode lightNode("light", "switch");
@@ -21,7 +22,7 @@ void setup() {
   pinMode(PIN_RELAY, OUTPUT);
   digitalWrite(PIN_RELAY, LOW);
 
-  Homie_setFirmware("awesome-relay", "1.0.0");
+  Homie_setFirmware("awesome-relay", firmwareVersion);
 
   lightNode.advertise("on").settable(lightOnHandler);
 


### PR DESCRIPTION
Not being able to simple insert a variable as parameter to the function `Homie_setFirmware` comes as a surprise. After checking the macro behind it, I believe this is the cleanest option for outsourcing of the firmware version - which you might want to do in bigger programs.

I wasn't sure where to put this info, decided to go with one of the basic examples and the api reference documentation. Better ideas?