### PR TITLE
Subscribing to messages using Homie.getMqttClient() is not reliable: topic is truncated

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -20,8 +20,9 @@ BootNormal::BootNormal()
   , _mqttWillTopic(nullptr)
   , _mqttPayloadBuffer(nullptr)
   , _mqttTopicLevels(nullptr)
-  , _mqttTopicLevelsCount(0) {
-  strlcpy(_fwChecksum, ESP.getSketchMD5().c_str(), sizeof(_fwChecksum));
+  , _mqttTopicLevelsCount(0)
+  , _mqttTopicCopy(nullptr)
+  {strlcpy(_fwChecksum, ESP.getSketchMD5().c_str(), sizeof(_fwChecksum));
   _fwChecksum[sizeof(_fwChecksum) - 1] = '\0';
 }
 
@@ -519,23 +520,28 @@ void BootNormal::_onMqttDisconnected(AsyncMqttClientDisconnectReason reason) {
 void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
   if (total == 0) return;  // no empty message possible
 
+  size_t topicLength = strlen(topic);
+  _mqttTopicCopy = std::unique_ptr<char[]>(new char[topicLength+1]);
+  memcpy(_mqttTopicCopy.get(), topic, topicLength);
+  _mqttTopicCopy.get()[topicLength] = '\0';
+  
   // split topic on each "/"
   if (index == 0) {
-    __splitTopic(topic);
+    __splitTopic(_mqttTopicCopy.get());
   }
 
   // 1. Handle OTA firmware (not copied to payload buffer)
-  if (__handleOTAUpdates(topic, payload, properties, len, index, total))
+  if (__handleOTAUpdates(_mqttTopicCopy.get(), payload, properties, len, index, total))
     return;
 
   // 2. Fill Payload Buffer
-  if (__fillPayloadBuffer(topic, payload, properties, len, index, total))
+  if (__fillPayloadBuffer(_mqttTopicCopy.get(), payload, properties, len, index, total))
     return;
 
   /* Arrived here, the payload is complete */
 
   // 3. handle broadcasts
-  if (__handleBroadcasts(topic, payload, properties, len, index, total))
+  if (__handleBroadcasts(_mqttTopicCopy.get(), payload, properties, len, index, total))
     return;
 
   // 4.all following messages are only for this deviceId
@@ -543,15 +549,15 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
     return;
 
   // 5. handle reset
-  if (__handleResets(topic, payload, properties, len, index, total))
+  if (__handleResets(_mqttTopicCopy.get(), payload, properties, len, index, total))
     return;
 
   // 6. handle config set
-  if (__handleConfig(topic, payload, properties, len, index, total))
+  if (__handleConfig(_mqttTopicCopy.get(), payload, properties, len, index, total))
     return;
 
   // 7. here, we're sure we have a node property
-  if (__handleNodeProperty(topic, payload, properties, len, index, total))
+  if (__handleNodeProperty(_mqttTopicCopy.get(), payload, properties, len, index, total))
     return;
 }
 

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -524,7 +524,7 @@ void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessa
   _mqttTopicCopy = std::unique_ptr<char[]>(new char[topicLength+1]);
   memcpy(_mqttTopicCopy.get(), topic, topicLength);
   _mqttTopicCopy.get()[topicLength] = '\0';
-  
+
   // split topic on each "/"
   if (index == 0) {
     __splitTopic(_mqttTopicCopy.get());

--- a/src/Homie/Boot/BootNormal.hpp
+++ b/src/Homie/Boot/BootNormal.hpp
@@ -86,6 +86,7 @@ class BootNormal : public Boot {
   std::unique_ptr<char[]> _mqttPayloadBuffer;
   std::unique_ptr<char*[]> _mqttTopicLevels;
   uint8_t _mqttTopicLevelsCount;
+  std::unique_ptr<char[]> _mqttTopicCopy;
 
   void _wifiConnect();
   void _onWifiGotIp(const WiFiEventStationModeGotIP& event);


### PR DESCRIPTION
It is not possible to subscribe to MQTT messages in general using Homie framework, as BootNormal::_onMqttMessage() truncates the topic.
[Issue #524](https://github.com/marvinroger/homie-esp8266/issues/524) 

With this change, topics can afterwards be intercepted by any other subscribed function, without loosing functionality
