### PR TITLE
Added compiler flag for disabling mDNS

### DIFF
--- a/docs/advanced-usage/compiler-flags.md
+++ b/docs/advanced-usage/compiler-flags.md
@@ -1,0 +1,11 @@
+Compiler flags can be used to remove certain functionality from homie-esp8266. This can become useful if your firmware gets too large in size and is not upgradable any more over OTA. On the other hand these compiler flags allow to remove features from homie-esp8266, that you do not require or do not use.
+
+## HOMIE_MDNS
+
+This compiler flag allows to disable the publishing of the device identifier via mDNS protocol. Add the following to your platformio.ini file:
+
+```
+build_flags = -D HOMIE_MDNS=0
+```
+
+This reduces the firmware size by about 6400 bytes.

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -292,7 +292,9 @@ void BootNormal::_onWifiGotIp(const WiFiEventStationModeGotIP& event) {
   Interface::get().event.mask = event.mask;
   Interface::get().event.gateway = event.gw;
   Interface::get().eventHandler(Interface::get().event);
+#if HOMIE_MDNS
   MDNS.begin(Interface::get().getConfig().get().deviceId);
+#endif
 
   _mqttConnect();
 }

--- a/src/Homie/Boot/BootNormal.hpp
+++ b/src/Homie/Boot/BootNormal.hpp
@@ -1,3 +1,7 @@
+#ifndef HOMIE_MDNS
+#define HOMIE_MDNS 1
+#endif
+
 #pragma once
 
 #include "Arduino.h"
@@ -5,7 +9,9 @@
 #include <functional>
 #include <libb64/cdecode.h>
 #include <ESP8266WiFi.h>
+#if HOMIE_MDNS
 #include <ESP8266mDNS.h>
+#endif
 #include <AsyncMqttClient.h>
 #include "../../HomieNode.hpp"
 #include "../../HomieRange.hpp"


### PR DESCRIPTION
Disabling mDNS in homie-esp8266 saves 6456 bytes of flash. I am trying to reduce the overall firmware size by disabling functionality, that I don't need.

I use ESP-01 and the 1MB flash size is too small to get OTA working. Therefore making homie-esp8266 is maybe an option to reduce firmware size and make OTA work on small devices.