### PR TITLE
added compiler flag for disabling the config mode

### DIFF
--- a/docs/advanced-usage/compiler-flags.md
+++ b/docs/advanced-usage/compiler-flags.md
@@ -1,0 +1,11 @@
+Compiler flags can be used to remove certain functionality from homie-esp8266. This can become useful if your firmware gets too large in size and is not upgradable any more over OTA. On the other hand these compiler flags allow to remove features from homie-esp8266, that you do not require or do not use.
+
+## HOMIE_CONFIG
+
+This compiler flag allows to disable the configuration mode completely. To configure your homie-esp8266, you need to upload the configuration to the SPIFFS before starting the device. Without a proper configuration the device will just restart after writing the error message about the missing configuration to the logger. Add the following to your platformio.ini file:
+
+```
+build_flags = -D HOMIE_CONFIG=0
+```
+
+This reduces the firmware size by about 50000 bytes.

--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -107,7 +107,11 @@ void HomieClass::setup() {
     Interface::get().getConfig().setHomieBootModeOnNextBoot(HomieBootMode::UNDEFINED);
   }
 
+#if HOMIE_CONFIG
   HomieBootMode _selectedHomieBootMode = HomieBootMode::CONFIGURATION;
+#else
+  HomieBootMode _selectedHomieBootMode = HomieBootMode::NORMAL;
+#endif
 
   // select boot mode source
   if (_applicationHomieBootMode != HomieBootMode::UNDEFINED) {
@@ -120,8 +124,13 @@ void HomieClass::setup() {
 
   // validate selected mode and fallback as needed
   if (_selectedHomieBootMode == HomieBootMode::NORMAL && !Interface::get().getConfig().load()) {
+#if HOMIE_CONFIG
     Interface::get().getLogger() << F("Configuration invalid. Using CONFIG MODE") << endl;
     _selectedHomieBootMode = HomieBootMode::CONFIGURATION;
+#else
+    Interface::get().getLogger() << F("Configuration invalid. CONFIG MODE is disabled.") << endl;
+    ESP.restart();
+#endif
   }
 
   // run selected mode
@@ -129,10 +138,12 @@ void HomieClass::setup() {
     _boot = &_bootNormal;
     Interface::get().event.type = HomieEventType::NORMAL_MODE;
     Interface::get().eventHandler(Interface::get().event);
+#if HOMIE_CONFIG
   } else if (_selectedHomieBootMode == HomieBootMode::CONFIGURATION) {
     _boot = &_bootConfig;
     Interface::get().event.type = HomieEventType::CONFIGURATION_MODE;
     Interface::get().eventHandler(Interface::get().event);
+#endif
   } else if (_selectedHomieBootMode == HomieBootMode::STANDALONE) {
     _boot = &_bootStandalone;
     Interface::get().event.type = HomieEventType::STANDALONE_MODE;

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -73,7 +73,9 @@ class HomieClass {
   Boot* _boot;
   BootStandalone _bootStandalone;
   BootNormal _bootNormal;
+#if HOMIE_CONFIG
   BootConfig _bootConfig;
+#endif
   bool _flaggedForReboot;
   SendingPromise _sendingPromise;
   Logger _logger;

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -1,5 +1,6 @@
 #include "BootConfig.hpp"
 
+#if HOMIE_CONFIG
 using namespace HomieInternals;
 
 BootConfig::BootConfig()
@@ -437,3 +438,4 @@ void HomieInternals::BootConfig::__SendJSONError(AsyncWebServerRequest * request
   String errorJson = BEGINNING + msg + END;
   request->send(code, FPSTR(PROGMEM_CONFIG_APPLICATION_JSON), errorJson);
 }
+#endif

--- a/src/Homie/Boot/BootConfig.hpp
+++ b/src/Homie/Boot/BootConfig.hpp
@@ -22,6 +22,7 @@
 #include "../../HomieSetting.hpp"
 #include "../../StreamingOperator.hpp"
 
+#if HOMIE_CONFIG
 namespace HomieInternals {
 class BootConfig : public Boot {
  public:
@@ -61,3 +62,5 @@ class BootConfig : public Boot {
   static void __SendJSONError(AsyncWebServerRequest *request, String msg, int16_t code = 400);
 };
 }  // namespace HomieInternals
+
+#endif

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -75,7 +75,9 @@ void BootNormal::setup() {
 
   if (Interface::get().getConfig().get().mqtt.auth) Interface::get().getMqttClient().setCredentials(Interface::get().getConfig().get().mqtt.username, Interface::get().getConfig().get().mqtt.password);
 
+#if HOMIE_CONFIG
   ResetHandler::Attach();
+#endif
 
   Interface::get().getConfig().log();
 

--- a/src/Homie/Boot/BootStandalone.cpp
+++ b/src/Homie/Boot/BootStandalone.cpp
@@ -14,7 +14,9 @@ void BootStandalone::setup() {
 
   WiFi.mode(WIFI_OFF);
 
+#if HOMIE_CONFIG
   ResetHandler::Attach();
+#endif
 }
 
 void BootStandalone::loop() {

--- a/src/Homie/Constants.hpp
+++ b/src/Homie/Constants.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef HOMIE_CONFIG
+#define HOMIE_CONFIG 1
+#endif
+
 #include <ESP8266WiFi.h>
 
 namespace HomieInternals {

--- a/src/Homie/Utils/ResetHandler.cpp
+++ b/src/Homie/Utils/ResetHandler.cpp
@@ -1,5 +1,6 @@
 #include "ResetHandler.hpp"
 
+#if HOMIE_CONFIG
 using namespace HomieInternals;
 
 Ticker ResetHandler::_resetBTNTicker;
@@ -49,3 +50,4 @@ void ResetHandler::_handleReset() {
     _sentReset = true;
   }
 }
+#endif

--- a/src/Homie/Utils/ResetHandler.hpp
+++ b/src/Homie/Utils/ResetHandler.hpp
@@ -7,6 +7,7 @@
 #include "../../StreamingOperator.hpp"
 #include "../Datatypes/Interface.hpp"
 
+#if HOMIE_CONFIG
 namespace HomieInternals {
 class ResetHandler {
  public:
@@ -23,3 +24,4 @@ class ResetHandler {
   static void _handleReset();
 };
 }  // namespace HomieInternals
+#endif

--- a/src/HomieBootMode.hpp
+++ b/src/HomieBootMode.hpp
@@ -3,6 +3,8 @@
 enum class HomieBootMode : uint8_t {
   UNDEFINED = 0,
   STANDALONE = 1,
+#if HOMIE_CONFIG
   CONFIGURATION = 2,
+#endif
   NORMAL = 3
 };


### PR DESCRIPTION
The added compiler flag that allows to remove the config mode from the code completely during compile run. This reduces the size of my empty test firmware by 50760 bytes.