### PR TITLE
Add an event that is fired whenever statistics are sent 

### DIFF
--- a/docs/advanced-usage/events.md
+++ b/docs/advanced-usage/events.md
@@ -55,6 +55,9 @@ void onHomieEvent(const HomieEvent& event) {
     case HomieEventType::READY_TO_SLEEP:
       // After you've called `prepareToSleep()`, the event is triggered when MQTT is disconnected
       break;
+    case HomieEventType::SENDING_STATISTICS:
+      // Do whatever you want when statistics are sent in normal mode
+      break;
   }
 }
 

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -316,6 +316,7 @@ void BootNormal::_onWifiDisconnected(const WiFiEventStationModeDisconnected& eve
 void BootNormal::_mqttConnect() {
   if (!Interface::get().disable) {
     if (Interface::get().led.enabled) Interface::get().getBlinker().start(LED_MQTT_DELAY);
+    _mqttConnectNotified = false;
     Interface::get().getLogger() << F("↕ Attempting to connect to MQTT...") << endl;
     Interface::get().getMqttClient().connect();
   }

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -158,6 +158,9 @@ void BootNormal::loop() {
     uint16_t uptimePacketId = Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$stats/uptime")), 1, true, uptimeStr);
 
     if (signalPacketId != 0 && uptimePacketId != 0) _statsTimer.tick();
+
+    Interface::get().event.type = HomieEventType::SENDING_STATISICS;
+    Interface::get().eventHandler(Interface::get().event);
   }
 
   Interface::get().loopFunction();
@@ -313,7 +316,6 @@ void BootNormal::_onWifiDisconnected(const WiFiEventStationModeDisconnected& eve
 void BootNormal::_mqttConnect() {
   if (!Interface::get().disable) {
     if (Interface::get().led.enabled) Interface::get().getBlinker().start(LED_MQTT_DELAY);
-    _mqttConnectNotified = false;
     Interface::get().getLogger() << F("↕ Attempting to connect to MQTT...") << endl;
     Interface::get().getMqttClient().connect();
   }

--- a/src/HomieEvent.hpp
+++ b/src/HomieEvent.hpp
@@ -17,7 +17,8 @@ enum class HomieEventType : uint8_t {
   MQTT_READY,
   MQTT_DISCONNECTED,
   MQTT_PACKET_ACKNOWLEDGED,
-  READY_TO_SLEEP
+  READY_TO_SLEEP,
+  SENDING_STATISICS
 };
 
 struct HomieEvent {


### PR DESCRIPTION
I felt the need for an event that gets fired whenever Homie sends its statistics. 
E.G. currently I use this to send the free heap via MQTT.