### PR TITLE
Update ArduinoJson Dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -22,7 +22,7 @@
   "dependencies": [
     {
       "name": "ArduinoJson",
-      "version": "^5.10.0"
+      "version": ">=5.10.0, <6"
     },
     {
       "name": "AsyncMqttClient",


### PR DESCRIPTION
v6 and above of ArduinoJson breaks the build. 

Modified to Greater than or equal to 5.10.0 (version from original library.json) and less than 6.

Figured this can get down the road until refactor for v6+

Also, as an addendum - This is my first PR on git, please forgive me if I have done this incorrectly.