### PR TITLE
SSL support for MQTT connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,19 +21,19 @@ jobs:
       - run:
           name: install examples dependencies
           command: platformio lib -g install Shutters@2.1.1 SonoffDual@1.1.0
-      - run: platformio ci ./examples/Broadcast --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/CustomSettings --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/DoorSensor --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/GlobalInputHandler --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/HookToEvents --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/IteadSonoff --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/IteadSonoffButton --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/LedStrip --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/LightOnOff --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/Ping --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/SingleButton --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/SonoffDualShutters --board=esp01 --board=nodemcuv2 --board=esp32dev
-      - run: platformio ci ./examples/TemperatureSensor --board=esp01 --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/Broadcast --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/CustomSettings --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/DoorSensor --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/GlobalInputHandler --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/HookToEvents --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/IteadSonoff --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/IteadSonoffButton --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/LedStrip --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/LightOnOff --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/Ping --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/SingleButton --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/SonoffDualShutters --board=esp01_1m --board=nodemcuv2 --board=esp32dev
+      - run: platformio ci ./examples/TemperatureSensor --board=esp01_1m --board=nodemcuv2 --board=esp32dev
 
   lint:
     working_directory: ~/code

--- a/docs/advanced-usage/compiler-flags.md
+++ b/docs/advanced-usage/compiler-flags.md
@@ -1,4 +1,8 @@
-Compiler flags can be used to remove certain functionality from homie-esp8266. This can become useful if your firmware gets too large in size and is not upgradable any more over OTA. On the other hand these compiler flags allow to remove features from homie-esp8266, that you do not require or do not use.
+Compiler flags can be used to add or remove certain functionality from homie-esp8266.
+
+Removing functionality can become useful if your firmware gets too large in size and is not upgradable any more over OTA. On the other hand these compiler flags allow to remove features from homie-esp8266, that you do not require or do not use.
+
+Adding functionality or features is useful to enable only partly implemented features or unstable or experimental features.
 
 **HOMIE_CONFIG**
 
@@ -20,4 +24,14 @@ build_flags = -D HOMIE_MDNS=0
 
 This reduces the firmware size by about 6400 bytes.
 
+**ASYNC_TCP_SSL_ENABLED**
 
+This compiler flag allows to use SSL encryption for MQTT connections. All other network connections still can not be encrypted like HTTP or OTA.
+
+```
+build_flags =
+  -D ASYNC_TCP_SSL_ENABLED=1
+  -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+```
+
+The additional flag `PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWITH` is necessary for SSL encryptions to work properly.

--- a/docs/configuration/json-configuration-file.md
+++ b/docs/configuration/json-configuration-file.md
@@ -24,7 +24,9 @@ Below is the format of the JSON configuration you will have to provide:
     "base_topic": "devices/",
     "auth": true,
     "username": "user",
-    "password": "pass"
+    "password": "pass",
+    "ssl": true,
+    "ssl_fingerprint": "a27992d3420c89f293d351378ba5f5675f74fe3c"
   },
   "ota": {
     "enabled": true
@@ -46,6 +48,7 @@ Here are the rules:
    - `bssid` and `channel` have to be defined together and these settings are independand of settings related to static IP
    - to define static IP, `ip` (IP address), `mask` (netmask) and `gw` (gateway) settings have to be defined at the same time
    - to define second DNS `dns2` the first one `dns1` has to be defined. Set DNS without `ip`, `mask` and `gw` does not affect the configuration (dns server will be provided by DHCP). It is not required to set DNS servers.
+* `ssl_fingerprint` can optionally be defined if `ssl` is enabled. The public key of the MQTT server is then verified against the fingerprint.
 
 Default values if not provided:
 

--- a/docs/others/limitations-and-known-issues.md
+++ b/docs/others/limitations-and-known-issues.md
@@ -1,6 +1,6 @@
 # SSL support
 
-In Homie for ESP8266 v1.x, SSL was possible but it was not reliable. Due to the asynchronous nature of the v2.x, SSL is not available anymore.
+In Homie for ESP8266 v1.x, SSL was possible but it was not reliable. Due to the asynchronous nature of the v2.x, SSL is not completely available anymore. Only MQTT connections can be encrypted with SSL.
 
 # ADC readings
 

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -34,7 +34,7 @@ void BootConfig::setup() {
   WiFi.mode(WIFI_AP_STA);
 
   char apName[MAX_WIFI_SSID_LENGTH];
-  strlcpy(apName, Interface::get().brand, MAX_WIFI_SSID_LENGTH - 1 - MAX_MAC_STRING_LENGTH);
+  strlcpy(apName, Interface::get().brand, MAX_WIFI_SSID_LENGTH - 1 - (MAX_MAC_STRING_LENGTH - 1));
   strcat_P(apName, PSTR("-"));
   strcat(apName, DeviceId::get());
 

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -72,6 +72,18 @@ void BootNormal::setup() {
   Interface::get().getMqttClient().onPublish(std::bind(&BootNormal::_onMqttPublish, this, std::placeholders::_1));
 
   Interface::get().getMqttClient().setServer(Interface::get().getConfig().get().mqtt.server.host, Interface::get().getConfig().get().mqtt.server.port);
+
+#if ASYNC_TCP_SSL_ENABLED
+  Interface::get().getLogger() << "SSL is: " << Interface::get().getConfig().get().mqtt.server.ssl.enabled << endl;
+  Interface::get().getMqttClient().setSecure(Interface::get().getConfig().get().mqtt.server.ssl.enabled);
+  if (Interface::get().getConfig().get().mqtt.server.ssl.enabled && Interface::get().getConfig().get().mqtt.server.ssl.hasFingerprint) {
+    char hexBuf[MAX_FINGERPRINT_SIZE * 2 + 1];
+    Helpers::byteArrayToHexString(Interface::get().getConfig().get().mqtt.server.ssl.fingerprint, hexBuf, MAX_FINGERPRINT_SIZE);
+    Interface::get().getLogger() << "Using fingerprint: " << hexBuf << endl;
+    Interface::get().getMqttClient().addServerFingerprint((const uint8_t*)Interface::get().getConfig().get().mqtt.server.ssl.fingerprint);
+  }
+#endif
+
   Interface::get().getMqttClient().setMaxTopicLength(MAX_MQTT_TOPIC_LENGTH);
   _mqttClientId = std::unique_ptr<char[]>(new char[strlen(Interface::get().brand) + 1 + strlen(Interface::get().getConfig().get().deviceId) + 1]);
   strcpy(_mqttClientId.get(), Interface::get().brand);

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -77,7 +77,7 @@ void BootNormal::setup() {
   Interface::get().getLogger() << "SSL is: " << Interface::get().getConfig().get().mqtt.server.ssl.enabled << endl;
   Interface::get().getMqttClient().setSecure(Interface::get().getConfig().get().mqtt.server.ssl.enabled);
   if (Interface::get().getConfig().get().mqtt.server.ssl.enabled && Interface::get().getConfig().get().mqtt.server.ssl.hasFingerprint) {
-    char hexBuf[MAX_FINGERPRINT_SIZE * 2 + 1];
+    char hexBuf[MAX_FINGERPRINT_STRING_LENGTH];
     Helpers::byteArrayToHexString(Interface::get().getConfig().get().mqtt.server.ssl.fingerprint, hexBuf, MAX_FINGERPRINT_SIZE);
     Interface::get().getLogger() << "Using fingerprint: " << hexBuf << endl;
     Interface::get().getMqttClient().addServerFingerprint((const uint8_t*)Interface::get().getConfig().get().mqtt.server.ssl.fingerprint);

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -152,11 +152,13 @@ bool Config::load() {
   strlcpy(_configStruct.wifi.dns1, reqWifiDns1, MAX_IP_STRING_LENGTH);
   strlcpy(_configStruct.wifi.dns2, reqWifiDns2, MAX_IP_STRING_LENGTH);
   strlcpy(_configStruct.mqtt.server.host, reqMqttHost, MAX_HOSTNAME_LENGTH);
+#if ASYNC_TCP_SSL_ENABLED
   _configStruct.mqtt.server.ssl.enabled = reqMqttSsl;
   if (strcmp_P(reqMqttFingerprint, PSTR("")) != 0) {
     _configStruct.mqtt.server.ssl.hasFingerprint = true;
     Helpers::hexStringToByteArray(reqMqttFingerprint, _configStruct.mqtt.server.ssl.fingerprint, MAX_FINGERPRINT_SIZE);
   }
+#endif
   _configStruct.mqtt.server.port = reqMqttPort;
   strlcpy(_configStruct.mqtt.baseTopic, reqMqttBaseTopic, MAX_MQTT_BASE_TOPIC_LENGTH);
   _configStruct.mqtt.auth = reqMqttAuth;
@@ -356,12 +358,14 @@ void Config::log() const {
   Interface::get().getLogger() << F("  • MQTT: ") << endl;
   Interface::get().getLogger() << F("    ◦ Host: ") << _configStruct.mqtt.server.host << endl;
   Interface::get().getLogger() << F("    ◦ Port: ") << _configStruct.mqtt.server.port << endl;
+#if ASYNC_TCP_SSL_ENABLED
   Interface::get().getLogger() << F("    ◦ SSL enabled: ") << (_configStruct.mqtt.server.ssl.enabled ? "true" : "false") << endl;
   if (_configStruct.mqtt.server.ssl.enabled && _configStruct.mqtt.server.ssl.hasFingerprint) {
-    char hexBuf[MAX_FINGERPRINT_SIZE * 2 + 1];
+    char hexBuf[MAX_FINGERPRINT_STRING_LENGTH];
     Helpers::byteArrayToHexString(Interface::get().getConfig().get().mqtt.server.ssl.fingerprint, hexBuf, MAX_FINGERPRINT_SIZE);
     Interface::get().getLogger() << F("    ◦ Fingerprint: ") << hexBuf << endl;
   }
+#endif
   Interface::get().getLogger() << F("    ◦ Base topic: ") << _configStruct.mqtt.baseTopic << endl;
   Interface::get().getLogger() << F("    ◦ Auth? ") << (_configStruct.mqtt.auth ? F("yes") : F("no")) << endl;
   if (_configStruct.mqtt.auth) {

--- a/src/Homie/Datatypes/ConfigStruct.hpp
+++ b/src/Homie/Datatypes/ConfigStruct.hpp
@@ -25,6 +25,11 @@ struct ConfigStruct {
     struct Server {
       char host[MAX_HOSTNAME_LENGTH];
       uint16_t port;
+      struct {
+        bool enabled;
+        bool hasFingerprint;
+        uint8_t fingerprint[MAX_FINGERPRINT_SIZE];
+      } ssl;
     } server;
     char baseTopic[MAX_MQTT_BASE_TOPIC_LENGTH];
     bool auth;

--- a/src/Homie/Datatypes/ConfigStruct.hpp
+++ b/src/Homie/Datatypes/ConfigStruct.hpp
@@ -25,11 +25,13 @@ struct ConfigStruct {
     struct Server {
       char host[MAX_HOSTNAME_LENGTH];
       uint16_t port;
+#if ASYNC_TCP_SSL_ENABLED
       struct {
         bool enabled;
         bool hasFingerprint;
         uint8_t fingerprint[MAX_FINGERPRINT_SIZE];
       } ssl;
+#endif
     } server;
     char baseTopic[MAX_MQTT_BASE_TOPIC_LENGTH];
     bool auth;

--- a/src/Homie/Limits.hpp
+++ b/src/Homie/Limits.hpp
@@ -10,9 +10,13 @@ namespace HomieInternals {
   // 6 elements at root, 9 elements at wifi, 6 elements at mqtt, 1 element at ota, max settings elements
   const uint16_t MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE = JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(9) + JSON_OBJECT_SIZE(6) + JSON_OBJECT_SIZE(1) + JSON_OBJECT_SIZE(MAX_CONFIG_SETTING_SIZE);
 
+  const uint8_t MAX_MAC_LENGTH = 6;
+  const uint8_t MAX_MAC_STRING_LENGTH = (MAX_MAC_LENGTH * 2) + 1;
+
   const uint8_t MAX_WIFI_SSID_LENGTH = 32 + 1;
   const uint8_t MAX_WIFI_PASSWORD_LENGTH = 64 + 1;
   const uint16_t MAX_HOSTNAME_LENGTH = 255 + 1;
+  const uint8_t MAX_FINGERPRINT_SIZE = 20;
 
   const uint8_t MAX_MQTT_CREDS_LENGTH = 32 + 1;
   const uint8_t MAX_MQTT_BASE_TOPIC_LENGTH = 48 + 1;
@@ -31,5 +35,4 @@ namespace HomieInternals {
 
   const uint8_t MAX_IP_STRING_LENGTH = 16 + 1;
 
-  const uint8_t MAX_MAC_STRING_LENGTH = 12;
 }  // namespace HomieInternals

--- a/src/Homie/Limits.hpp
+++ b/src/Homie/Limits.hpp
@@ -17,6 +17,7 @@ namespace HomieInternals {
   const uint8_t MAX_WIFI_PASSWORD_LENGTH = 64 + 1;
   const uint16_t MAX_HOSTNAME_LENGTH = 255 + 1;
   const uint8_t MAX_FINGERPRINT_SIZE = 20;
+  const uint8_t MAX_FINGERPRINT_STRING_LENGTH = (MAX_FINGERPRINT_SIZE *2) + 1;
 
   const uint8_t MAX_MQTT_CREDS_LENGTH = 32 + 1;
   const uint8_t MAX_MQTT_BASE_TOPIC_LENGTH = 48 + 1;

--- a/src/Homie/Utils/DeviceId.cpp
+++ b/src/Homie/Utils/DeviceId.cpp
@@ -14,7 +14,7 @@ void DeviceId::generate() {
 void DeviceId::generate() {
   uint8_t mac[6];
   WiFi.macAddress(mac);
-  snprintf(DeviceId::_deviceId, MAX_MAC_STRING_LENGTH+1 , "%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  snprintf(DeviceId::_deviceId, MAX_MAC_STRING_LENGTH, "%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 }
 #endif // ESP32
 

--- a/src/Homie/Utils/DeviceId.hpp
+++ b/src/Homie/Utils/DeviceId.hpp
@@ -18,6 +18,6 @@ class DeviceId {
   static const char* get();
 
  private:
-  static char _deviceId[MAX_MAC_STRING_LENGTH + 1];
+  static char _deviceId[MAX_MAC_STRING_LENGTH];
 };
 }  // namespace HomieInternals

--- a/src/Homie/Utils/Helpers.cpp
+++ b/src/Homie/Utils/Helpers.cpp
@@ -55,7 +55,7 @@ bool Helpers::validateMacAddress(const char* mac) {
     }
     ++mac;
   }
-  return (i == MAX_MAC_STRING_LENGTH && s == 5);
+  return (i == MAX_MAC_LENGTH * 2 && s == 5);
 }
 
 bool Helpers::validateMd5(const char* md5) {

--- a/src/Homie/Utils/Helpers.cpp
+++ b/src/Homie/Utils/Helpers.cpp
@@ -82,3 +82,18 @@ std::unique_ptr<char[]> Helpers::cloneString(const String& string) {
 void Helpers::ipToString(const IPAddress& ip, char * str) {
   snprintf(str, MAX_IP_STRING_LENGTH, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
 }
+
+void Helpers::hexStringToByteArray(const char* hexStr, uint8_t* hexArray, uint8_t size) {
+  for (uint8_t i = 0; i < size; i++) {
+    char hex[3];
+    strncpy(hex, (hexStr + (i * 2)), 2);
+    hex[2] = '\0';
+    hexArray[i] = (uint8_t)strtol((const char*)&hex, nullptr, 16);
+  }
+}
+
+void Helpers::byteArrayToHexString(const uint8_t * hexArray, char* hexStr, uint8_t size) {
+  for (uint8_t i = 0; i < size; i++) {
+    snprintf((hexStr + (i * 2)), 3, "%02x", hexArray[i]);
+  }
+}

--- a/src/Homie/Utils/Helpers.hpp
+++ b/src/Homie/Utils/Helpers.hpp
@@ -17,5 +17,7 @@ class Helpers {
   static bool validateMd5(const char* md5);
   static std::unique_ptr<char[]> cloneString(const String& string);
   static void ipToString(const IPAddress& ip, char* str);
+  static void hexStringToByteArray(const char* hexStr, uint8_t* hexArray, uint8_t size);
+  static void byteArrayToHexString(const uint8_t* hexArray, char* hexStr, uint8_t size);
 };
 }  // namespace HomieInternals

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -402,5 +402,5 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& obj
 //    }
 //    ++mac;
 //   }
-//   return (i == MAX_MAC_STRING_LENGTH && s == 5);
+//   return (i == MAX_MAC_LENGTH * 2 && s == 5);
 // }

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -200,6 +200,23 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object)
     result.reason = F("mqtt.port is not an integer");
     return result;
   }
+  if (object["mqtt"].as<JsonObject&>().containsKey("ssl")) {
+    if (!object["mqtt"]["ssl"].is<bool>()) {
+      result.reason = F("mqtt.ssl is not a bool");
+      return result;
+    }
+  }
+  if (object["mqtt"].as<JsonObject&>().containsKey("ssl_fingerprint")) {
+    if (!object["mqtt"]["ssl_fingerprint"].is<const char*>()) {
+      result.reason = F("mqtt.ssl_fingerprint is not a string");
+      return result;
+    }
+
+    if (strlen(object["mqtt"]["ssl_fingerprint"]) > MAX_FINGERPRINT_SIZE * 2) {
+      result.reason = F("mqtt.ssl_fingerprint is too long");
+      return result;
+    }
+  }
   if (object["mqtt"].as<JsonObject&>().containsKey("base_topic")) {
     if (!object["mqtt"]["base_topic"].is<const char*>()) {
       result.reason = F("mqtt.base_topic is not a string");


### PR DESCRIPTION
This is stolen from timpur's v2.1 branch.
I like to encrypt my MQTT connections because passwords are transmitted over MQTT in clear text. Passwords transmitted in clear text should be always avoided.