### PR TITLE
correction of some GitHub URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ If you have some questions or if you need help, some people might help you on th
 
 Before submitting your issue, make sure:
 
-- [ ] You've read the documentation for *your* release (in the `docs/` folder or at http://marvinroger.github.io/homie-esp8266/) which contains some answsers to the most common problems (notably the `Limitations and know issues` and `Troubleshooting` pages)
+- [ ] You've read the documentation for *your* release (in the `docs/` folder or at https://homieiot.github.io/homie-esp8266/) which contains some answsers to the most common problems (notably the `Limitations and know issues` and `Troubleshooting` pages)
 - [ ] You're using the examples bundled in *your* release, which are in the `examples/` folder of the `.zip` of the release you're using. Examples might not be backward-compatible
 
 Thanks!

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /config.json
 *.filters
 *.vcxitems
+.vscode/

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@ Docs
 Docs are available:
 
 * Locally at [index.md](index.md)
-* Online at http://marvinroger.github.io/homie-esp8266/
+* Online at https://homieiot.github.io/homie-esp8266

--- a/docs/configuration/http-json-api.md
+++ b/docs/configuration/http-json-api.md
@@ -2,7 +2,7 @@ When in `configuration` mode, the device exposes a HTTP JSON API to send the con
 
 If you don't want to mess with JSON, you have a Web UI / app available:
 
-* At http://marvinroger.github.io/homie-esp8266/configurators/v2/
+* At http://homieiot.github.io/homie-esp8266/configurators/v2/
 * As an [Android app](https://build.phonegap.com/apps/1906578/share)
 
 **Quick instructions to use the Web UI / app**:

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "keywords": "iot, home, automation, mqtt, esp8266, async, sensor",
   "description": "ESP8266 framework for Homie, a lightweight MQTT convention for the IoT",
-  "homepage": "http://marvinroger.github.io/homie-esp8266/",
+  "homepage": "https://homieiot.github.io/homie-esp8266/",
   "license": "MIT",
   "authors":
   {

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -255,7 +255,7 @@ void BootConfig::_onCaptivePortal(AsyncWebServerRequest *request) {
     }
   } else if (request->url() == "/" && !SPIFFS.exists(CONFIG_UI_BUNDLE_PATH)) {
     // UI File not found
-    String msg = String(F("UI bundle not loaded. See Configuration API usage: http://marvinroger.github.io/homie-esp8266/"));
+    String msg = String(F("UI bundle not loaded. See Configuration API usage: http://homieiot.github.io/homie-esp8266"));
     Interface::get().getLogger() << msg << endl;
     request->send(404, F("text/plain"), msg);
   } else if (request->url() == "/" && SPIFFS.exists(CONFIG_UI_BUNDLE_PATH)) {


### PR DESCRIPTION
Correction of some URLs after the movement to organisation `homieiot`:

`http://marvinroger.github.io/homie-esp8266/` -> `https://homieiot.github.io/homie-esp8266/`

