### PR TITLE
Fixed device not reconnecting after MQTT connection loss

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -518,9 +518,9 @@ void BootNormal::_onMqttDisconnected(AsyncMqttClientDisconnectReason reason) {
 
     _mqttConnect();
 
-  } else {
-    _mqttReconnectTimer.activate();
   }
+  _mqttReconnectTimer.activate();
+  
 }
 
 void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -517,10 +517,8 @@ void BootNormal::_onMqttDisconnected(AsyncMqttClientDisconnectReason reason) {
     }
 
     _mqttConnect();
-
   }
   _mqttReconnectTimer.activate();
-  
 }
 
 void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {


### PR DESCRIPTION
MQTT was not reconnecting after a loss, since BootNormal::_onMqttDisconnected had to be called [twice](https://github.com/homieiot/homie-esp8266/blob/develop/src/Homie/Boot/BootNormal.cpp#L500) in order to periodically try to reconnect.

In my tests it got called only once, leading to only one singe reconnection attempt.