### PR TITLE
Config: fix buffer overflow when loading json config

### DIFF
--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -39,7 +39,7 @@ bool Config::load() {
 
   size_t configSize = configFile.size();
 
-  if (configSize > MAX_JSON_CONFIG_FILE_SIZE) {
+  if (configSize >= MAX_JSON_CONFIG_FILE_SIZE) {
     Interface::get().getLogger() << F("✖ Config file too big") << endl;
     return false;
   }


### PR DESCRIPTION
When the configSize is MAX_JSON_CONFIG_FILE_SIZE the '\0' is written
after the buffers end. Don't load config files with a
size >= MAX_JSON_CONFIG_FILE_SIZE.

Signed-off-by: Philipp Rosenberger <code@iluminat23.org>