### PR TITLE
Migrate to ArduinoJson version 6

### DIFF
--- a/library.json
+++ b/library.json
@@ -22,7 +22,7 @@
   "dependencies": [
     {
       "name": "ArduinoJson",
-      "version": "^5.10.0"
+      "version": "^6.11.4"
     },
     {
       "name": "AsyncMqttClient",

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -129,14 +129,16 @@ void BootConfig::_onWifiConnectRequest(AsyncWebServerRequest *request) {
   }
 
   JsonObject parsedJson = parseJsonDoc.as<JsonObject>();
+  JsonVariant jvWiFiSsid = parsedJson["ssid"];
+  JsonVariant jvWiFiPassword = parsedJson["password"];
 
-  if (!parsedJson.containsKey("ssid") || !parsedJson["ssid"].is<const char*>() || !parsedJson.containsKey("password") || !parsedJson["password"].is<const char*>()) {
+  if (!jvWiFiSsid.is<const char*>() || !jvWiFiPassword.is<const char*>()) {
     __SendJSONError(request, F("✖ SSID and password required"));
     return;
   }
 
   Interface::get().getLogger() << F("Connecting to Wi-Fi") << endl;
-  WiFi.begin(parsedJson["ssid"].as<const char*>(), parsedJson["password"].as<const char*>());
+  WiFi.begin(jvWiFiSsid.as<const char*>(), jvWiFiPassword.as<const char*>());
 
   request->send(202, FPSTR(PROGMEM_CONFIG_APPLICATION_JSON), FPSTR(PROGMEM_CONFIG_JSON_SUCCESS));
 }
@@ -191,13 +193,14 @@ void BootConfig::_onProxyControlRequest(AsyncWebServerRequest *request) {
   }
 
   JsonObject parsedJson = parseJsonDoc.as<JsonObject>();
+  JsonVariant jvProxyEnabled = parsedJson["enable"];
 
-  if (!parsedJson.containsKey("enable") || !parsedJson["enable"].is<bool>()) {
+  if (!jvProxyEnabled.is<bool>()) {
     __SendJSONError(request, F("✖ enable parameter is required"));
     return;
   }
 
-  _proxyEnabled = parsedJson["enable"];
+  _proxyEnabled = jvProxyEnabled.as<bool>();
 
   request->send(202, FPSTR(PROGMEM_CONFIG_APPLICATION_JSON), FPSTR(PROGMEM_CONFIG_JSON_SUCCESS));
 }

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -342,7 +342,7 @@ void BootConfig::_onDeviceInfoRequest(AsyncWebServerRequest *request) {
   Interface::get().getLogger() << F("Received device information request") << endl;
   auto numSettings = IHomieSetting::settings.size();
   auto numNodes = HomieNode::nodes.size();
-  DynamicJsonDocument jsonDoc(JSON_OBJECT_SIZE(5) + JSON_OBJECT_SIZE(2) + JSON_ARRAY_SIZE(numNodes) + (numNodes * JSON_OBJECT_SIZE(2)) + JSON_ARRAY_SIZE(numSettings) + (numSettings * JSON_OBJECT_SIZE(5)));
+  DynamicJsonDocument jsonDoc(JSON_OBJECT_SIZE(1) + JSON_OBJECT_SIZE(5) + JSON_OBJECT_SIZE(2) + JSON_ARRAY_SIZE(numNodes) + (numNodes * JSON_OBJECT_SIZE(2)) + JSON_ARRAY_SIZE(numSettings) + (numSettings * JSON_OBJECT_SIZE(5)));
   JsonObject json = jsonDoc.to<JsonObject>();
   json["hardware_device_id"] = DeviceId::get();
   json["homie_esp8266_version"] = HOMIE_ESP8266_VERSION;
@@ -386,7 +386,7 @@ void BootConfig::_onDeviceInfoRequest(AsyncWebServerRequest *request) {
   }
 
   String output;
-  serializeJson(json, output);
+  serializeJson(jsonDoc, output);
 
   request->send(200, FPSTR(PROGMEM_CONFIG_APPLICATION_JSON), output);
 }

--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -121,13 +121,14 @@ void BootConfig::loop() {
 
 void BootConfig::_onWifiConnectRequest(AsyncWebServerRequest *request) {
   Interface::get().getLogger() << F("Received Wi-Fi connect request") << endl;
-  DynamicJsonBuffer parseJsonBuffer(JSON_OBJECT_SIZE(2));
+  DynamicJsonDocument parseJsonDoc(JSON_OBJECT_SIZE(2));
   const char* body = (const char*)(request->_tempObject);
-  JsonObject& parsedJson = parseJsonBuffer.parseObject(body);
-  if (!parsedJson.success()) {
+  if (deserializeJson(parseJsonDoc, body) != DeserializationError::Ok || !parseJsonDoc.is<JsonObject>()) {
     __SendJSONError(request, F("✖ Invalid or too big JSON"));
     return;
   }
+
+  JsonObject parsedJson = parseJsonDoc.as<JsonObject>();
 
   if (!parsedJson.containsKey("ssid") || !parsedJson["ssid"].is<const char*>() || !parsedJson.containsKey("password") || !parsedJson["password"].is<const char*>()) {
     __SendJSONError(request, F("✖ SSID and password required"));
@@ -143,8 +144,8 @@ void BootConfig::_onWifiConnectRequest(AsyncWebServerRequest *request) {
 void BootConfig::_onWifiStatusRequest(AsyncWebServerRequest *request) {
   Interface::get().getLogger() << F("Received Wi-Fi status request") << endl;
 
-  DynamicJsonBuffer generatedJsonBuffer(JSON_OBJECT_SIZE(2));
-  JsonObject& json = generatedJsonBuffer.createObject();
+  DynamicJsonDocument generatedJsonDoc(JSON_OBJECT_SIZE(2));
+  JsonObject json = generatedJsonDoc.to<JsonObject>();
   String status;
 
   //String json = "";
@@ -175,20 +176,21 @@ void BootConfig::_onWifiStatusRequest(AsyncWebServerRequest *request) {
 
   json["status"] = status;
   String output;
-  json.printTo(output);
+  serializeJson(generatedJsonDoc, output);
 
   request->send(200, FPSTR(PROGMEM_CONFIG_APPLICATION_JSON), output);
 }
 
 void BootConfig::_onProxyControlRequest(AsyncWebServerRequest *request) {
   Interface::get().getLogger() << F("Received proxy control request") << endl;
-  DynamicJsonBuffer parseJsonBuffer(JSON_OBJECT_SIZE(1));
+  DynamicJsonDocument parseJsonDoc(JSON_OBJECT_SIZE(1));
   const char* body = (const char*)(request->_tempObject);
-  JsonObject& parsedJson = parseJsonBuffer.parseObject(body);  // do not use plain String, else fails
-  if (!parsedJson.success()) {
+  if (deserializeJson(parseJsonDoc, body) != DeserializationError::Ok || !parseJsonDoc.is<JsonObject>()) { // do not use plain String, else fails
     __SendJSONError(request, F("✖ Invalid or too big JSON"));
     return;
   }
+
+  JsonObject parsedJson = parseJsonDoc.as<JsonObject>();
 
   if (!parsedJson.containsKey("enable") || !parsedJson["enable"].is<bool>()) {
     __SendJSONError(request, F("✖ enable parameter is required"));
@@ -201,12 +203,12 @@ void BootConfig::_onProxyControlRequest(AsyncWebServerRequest *request) {
 }
 
 void BootConfig::_generateNetworksJson() {
-  DynamicJsonBuffer generatedJsonBuffer(JSON_OBJECT_SIZE(1) + JSON_ARRAY_SIZE(_ssidCount) + (_ssidCount * JSON_OBJECT_SIZE(3)));  // 1 at root, 3 in childrend
-  JsonObject& json = generatedJsonBuffer.createObject();
+  DynamicJsonDocument generatedJsonDoc(JSON_OBJECT_SIZE(1) + JSON_ARRAY_SIZE(_ssidCount) + (_ssidCount * JSON_OBJECT_SIZE(3)));  // 1 at root, 3 in childrend
+  JsonObject json = generatedJsonDoc.to<JsonObject>();
 
-  JsonArray& networks = json.createNestedArray("networks");
+  JsonArray networks = json.createNestedArray("networks");
   for (int network = 0; network < _ssidCount; network++) {
-    JsonObject& jsonNetwork = generatedJsonBuffer.createObject();
+    JsonObject jsonNetwork = networks.createNestedObject();
     jsonNetwork["ssid"] = WiFi.SSID(network);
     jsonNetwork["rssi"] = WiFi.RSSI(network);
     #ifdef ESP32
@@ -249,12 +251,10 @@ void BootConfig::_generateNetworksJson() {
       break;
     }
     #endif // ESP32
-
-    networks.add(jsonNetwork);
   }
 
   String output;
-  json.printTo(output);
+  serializeJson(generatedJsonDoc, output);
   _jsonWifiNetworks = output;
 }
 
@@ -339,25 +339,24 @@ void BootConfig::_onDeviceInfoRequest(AsyncWebServerRequest *request) {
   Interface::get().getLogger() << F("Received device information request") << endl;
   auto numSettings = IHomieSetting::settings.size();
   auto numNodes = HomieNode::nodes.size();
-  DynamicJsonBuffer jsonBuffer(JSON_OBJECT_SIZE(5) + JSON_OBJECT_SIZE(2) + JSON_ARRAY_SIZE(numNodes) + (numNodes * JSON_OBJECT_SIZE(2)) + JSON_ARRAY_SIZE(numSettings) + (numSettings * JSON_OBJECT_SIZE(5)));
-  JsonObject& json = jsonBuffer.createObject();
+  DynamicJsonDocument jsonDoc(JSON_OBJECT_SIZE(5) + JSON_OBJECT_SIZE(2) + JSON_ARRAY_SIZE(numNodes) + (numNodes * JSON_OBJECT_SIZE(2)) + JSON_ARRAY_SIZE(numSettings) + (numSettings * JSON_OBJECT_SIZE(5)));
+  JsonObject json = jsonDoc.to<JsonObject>();
   json["hardware_device_id"] = DeviceId::get();
   json["homie_esp8266_version"] = HOMIE_ESP8266_VERSION;
-  JsonObject& firmware = json.createNestedObject("firmware");
+  JsonObject firmware = json.createNestedObject("firmware");
   firmware["name"] = Interface::get().firmware.name;
   firmware["version"] = Interface::get().firmware.version;
 
-  JsonArray& nodes = json.createNestedArray("nodes");
+  JsonArray nodes = json.createNestedArray("nodes");
   for (HomieNode* iNode : HomieNode::nodes) {
-    JsonObject& jsonNode = jsonBuffer.createObject();
+    JsonObject jsonNode = nodes.createNestedObject();
     jsonNode["id"] = iNode->getId();
     jsonNode["type"] = iNode->getType();
-    nodes.add(jsonNode);
   }
 
-  JsonArray& settings = json.createNestedArray("settings");
+  JsonArray settings = json.createNestedArray("settings");
   for (IHomieSetting* iSetting : IHomieSetting::settings) {
-    JsonObject& jsonSetting = jsonBuffer.createObject();
+    JsonObject jsonSetting = settings.createNestedObject();
 
     if (strcmp(iSetting->getType(), "unknown") != 0) {
       jsonSetting["name"] = iSetting->getName();
@@ -381,12 +380,10 @@ void BootConfig::_onDeviceInfoRequest(AsyncWebServerRequest *request) {
         }
       }
     }
-
-    settings.add(jsonSetting);
   }
 
   String output;
-  json.printTo(output);
+  serializeJson(json, output);
 
   request->send(200, FPSTR(PROGMEM_CONFIG_APPLICATION_JSON), output);
 }
@@ -407,13 +404,14 @@ void BootConfig::_onConfigRequest(AsyncWebServerRequest *request) {
     return;
   }
 
-  DynamicJsonBuffer parseJsonBuffer(MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE);
+  DynamicJsonDocument parseJsonDoc(MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE);
   const char* body = (const char*)(request->_tempObject);
-  JsonObject& parsedJson = parseJsonBuffer.parseObject(body);
-  if (!parsedJson.success()) {
+  if (deserializeJson(parseJsonDoc, body) != DeserializationError::Ok || !parseJsonDoc.is<JsonObject>()) {
     __SendJSONError(request, F("✖ Invalid or too big JSON"));
     return;
   }
+
+  JsonObject parsedJson = parseJsonDoc.as<JsonObject>();
 
   ConfigValidationResult configValidationResult = Validation::validateConfig(parsedJson);
   if (!configValidationResult.valid) {

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -63,86 +63,109 @@ bool Config::load() {
     return false;
   }
 
+  // Mandatory config objects
+  JsonObject objReqWiFi = parsedJson["wifi"].as<JsonObject>();
+  JsonObject objReqMqtt = parsedJson["mqtt"].as<JsonObject>();
+  JsonObject objReqOta = parsedJson["ota"].as<JsonObject>();
+
+  // Mandatory config items
   const char* reqName = parsedJson["name"];
-  const char* reqWifiSsid = parsedJson["wifi"]["ssid"];
-  const char* reqWifiPassword = parsedJson["wifi"]["password"];
+  const char* reqWifiSsid = objReqWiFi["ssid"];
+  const char* reqWifiPassword = objReqWiFi["password"];
+  const char* reqMqttHost = objReqMqtt["host"];
 
-  const char* reqMqttHost = parsedJson["mqtt"]["host"];
+  // Defaults for optional config items
   const char* reqDeviceId = DeviceId::get();
-  if (parsedJson.containsKey("device_id")) {
-    reqDeviceId = parsedJson["device_id"];
-  }
-  uint16_t regDeviceStatsInterval = STATS_SEND_INTERVAL_SEC; //device_stats_interval
-  if (parsedJson.containsKey(F("device_stats_interval"))) {
-    regDeviceStatsInterval = parsedJson[F("device_stats_interval")];
-  }
-
+  uint16_t reqDeviceStatsInterval = STATS_SEND_INTERVAL_SEC; //device_stats_interval
   const char* reqWifiBssid = "";
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("bssid")) {
-    reqWifiBssid = parsedJson["wifi"]["bssid"];
-  }
   uint16_t reqWifiChannel = 0;
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("channel")) {
-    reqWifiChannel = parsedJson["wifi"]["channel"];
-  }
   const char* reqWifiIp = "";
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("ip")) {
-    reqWifiIp = parsedJson["wifi"]["ip"];
-  }
   const char* reqWifiMask = "";
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("mask")) {
-    reqWifiMask = parsedJson["wifi"]["mask"];
-  }
   const char* reqWifiGw = "";
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("gw")) {
-    reqWifiGw = parsedJson["wifi"]["gw"];
-  }
   const char* reqWifiDns1 = "";
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("dns1")) {
-    reqWifiDns1 = parsedJson["wifi"]["dns1"];
-  }
   const char* reqWifiDns2 = "";
-  if (parsedJson["wifi"].as<JsonObject>().containsKey("dns2")) {
-    reqWifiDns2 = parsedJson["wifi"]["dns2"];
-  }
-
   uint16_t reqMqttPort = DEFAULT_MQTT_PORT;
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("port")) {
-    reqMqttPort = parsedJson["mqtt"]["port"];
-  }
   bool reqMqttSsl = false;
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("ssl")) {
-    reqMqttSsl = parsedJson["mqtt"]["ssl"];
-  }
   const char* reqMqttFingerprint = "";
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("ssl_fingerprint")) {
-    reqMqttFingerprint = parsedJson["mqtt"]["ssl_fingerprint"];
-  }
   const char* reqMqttBaseTopic = DEFAULT_MQTT_BASE_TOPIC;
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("base_topic")) {
-    reqMqttBaseTopic = parsedJson["mqtt"]["base_topic"];
-  }
   bool reqMqttAuth = false;
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("auth")) {
-    reqMqttAuth = parsedJson["mqtt"]["auth"];
-  }
   const char* reqMqttUsername = "";
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("username")) {
-    reqMqttUsername = parsedJson["mqtt"]["username"];
-  }
   const char* reqMqttPassword = "";
-  if (parsedJson["mqtt"].as<JsonObject>().containsKey("password")) {
-    reqMqttPassword = parsedJson["mqtt"]["password"];
-  }
-
   bool reqOtaEnabled = false;
-  if (parsedJson["ota"].as<JsonObject>().containsKey("enabled")) {
-    reqOtaEnabled = parsedJson["ota"]["enabled"];
-  }
+
+  // JsonVariants for optional config items
+  JsonVariant jvReqDeviceId = parsedJson["device_id"];
+  JsonVariant jvReqDeviceStatsInterval = parsedJson["device_stats_interval"];
+  JsonVariant jvReqWifiBssid = objReqWiFi["bssid"];
+  JsonVariant jvReqWiFiChannel = objReqWiFi["channel"];
+  JsonVariant jvReqWiFiIp = objReqWiFi["ip"];
+  JsonVariant jvReqWiFiMask = objReqWiFi["mask"];
+  JsonVariant jvReqWiFiGw = objReqWiFi["gw"];
+  JsonVariant jvReqWiFiDns1 = objReqWiFi["dns1"];
+  JsonVariant jvReqWiFiDns2 = objReqWiFi["dns2"];
+  JsonVariant jvReqMqttPort = objReqMqtt["port"];
+  JsonVariant jvReqMqttSsl = objReqMqtt["ssl"];
+  JsonVariant jvReqMqttFingerprint = objReqMqtt["ssl_fingerprint"];
+  JsonVariant jvReqMqttBaseTopic = objReqMqtt["base_topic"];
+  JsonVariant jvReqMqttAuth = objReqMqtt["auth"];
+  JsonVariant jvReqMqttUsername = objReqMqtt["username"];
+  JsonVariant jvReqMqttPassword = objReqMqtt["password"];
+  JsonVariant jvReqOtaEnabled = objReqOta["enabled"];
+
+  if (!jvReqDeviceId.isNull())
+    reqDeviceId = jvReqDeviceId.as<const char*>();
+
+  if (!jvReqDeviceStatsInterval.isNull())
+    reqDeviceStatsInterval = jvReqDeviceStatsInterval.as<uint16_t>();
+
+  if (!jvReqWifiBssid.isNull())
+    reqWifiBssid = jvReqWifiBssid.as<const char*>();
+
+  if (!jvReqWiFiChannel.isNull())
+    reqWifiChannel = jvReqWiFiChannel.as<uint16_t>();
+
+  if (!jvReqWiFiIp.isNull())
+    reqWifiIp = jvReqWiFiIp.as<const char*>();
+
+  if (!jvReqWiFiMask.isNull())
+    reqWifiMask = jvReqWiFiMask.as<const char*>();
+
+  if (!jvReqWiFiGw.isNull())
+    reqWifiGw = jvReqWiFiGw.as<const char*>();
+
+  if (!jvReqWiFiDns1.isNull())
+    reqWifiDns1 = jvReqWiFiDns1.as<const char*>();
+
+  if (!jvReqWiFiDns2.isNull())
+    reqWifiDns2 = jvReqWiFiDns2.as<const char*>();
+
+  if (!jvReqMqttPort.isNull())
+    reqMqttPort = jvReqMqttPort.as<uint16_t>();
+
+  if (!jvReqMqttSsl.isNull())
+    reqMqttSsl = jvReqMqttSsl.as<bool>();
+
+  if (!jvReqMqttFingerprint.isNull())
+    reqMqttFingerprint = jvReqMqttFingerprint.as<const char*>();
+
+  if (!jvReqMqttBaseTopic.isNull())
+    reqMqttBaseTopic = jvReqMqttBaseTopic.as<const char*>();
+
+  if (!jvReqMqttAuth.isNull())
+    reqMqttAuth = jvReqMqttAuth.as<bool>();
+
+  if (!jvReqMqttUsername.isNull())
+    reqMqttUsername = jvReqMqttUsername.as<const char*>();
+
+  if (!jvReqMqttPassword.isNull())
+    reqMqttPassword = jvReqMqttPassword.as<const char*>();
+
+  if (!jvReqOtaEnabled.isNull())
+    reqOtaEnabled = jvReqOtaEnabled.as<bool>();
 
   strlcpy(_configStruct.name, reqName, MAX_FRIENDLY_NAME_LENGTH);
   strlcpy(_configStruct.deviceId, reqDeviceId, MAX_DEVICE_ID_LENGTH);
-  _configStruct.deviceStatsInterval = regDeviceStatsInterval;
+  _configStruct.deviceStatsInterval = reqDeviceStatsInterval;
   strlcpy(_configStruct.wifi.ssid, reqWifiSsid, MAX_WIFI_SSID_LENGTH);
   if (reqWifiPassword) strlcpy(_configStruct.wifi.password, reqWifiPassword, MAX_WIFI_PASSWORD_LENGTH);
   strlcpy(_configStruct.wifi.bssid, reqWifiBssid, MAX_MAC_STRING_LENGTH + 6);
@@ -172,29 +195,21 @@ bool Config::load() {
   JsonObject settingsObject = parsedJson["settings"].as<JsonObject>();
 
   for (IHomieSetting* iSetting : IHomieSetting::settings) {
-    if (iSetting->isBool()) {
-      HomieSetting<bool>* setting = static_cast<HomieSetting<bool>*>(iSetting);
+    JsonVariant jvSetting = settingsObject[iSetting->getName()];
 
-      if (settingsObject.containsKey(setting->getName())) {
-        setting->set(settingsObject[setting->getName()].as<bool>());
-      }
-    } else if (iSetting->isLong()) {
-      HomieSetting<long>* setting = static_cast<HomieSetting<long>*>(iSetting);
-
-      if (settingsObject.containsKey(setting->getName())) {
-        setting->set(settingsObject[setting->getName()].as<long>());
-      }
-    } else if (iSetting->isDouble()) {
-      HomieSetting<double>* setting = static_cast<HomieSetting<double>*>(iSetting);
-
-      if (settingsObject.containsKey(setting->getName())) {
-        setting->set(settingsObject[setting->getName()].as<double>());
-      }
-    } else if (iSetting->isConstChar()) {
-      HomieSetting<const char*>* setting = static_cast<HomieSetting<const char*>*>(iSetting);
-
-      if (settingsObject.containsKey(setting->getName())) {
-        setting->set(strdup(settingsObject[setting->getName()].as<const char*>()));
+    if (!jvSetting.isNull()) {
+      if (iSetting->isBool()) {
+        HomieSetting<bool>* setting = static_cast<HomieSetting<bool>*>(iSetting);
+        setting->set(jvSetting.as<bool>());
+      } else if (iSetting->isLong()) {
+        HomieSetting<long>* setting = static_cast<HomieSetting<long>*>(iSetting);
+        setting->set(jvSetting.as<long>());
+      } else if (iSetting->isDouble()) {
+        HomieSetting<double>* setting = static_cast<HomieSetting<double>*>(iSetting);
+        setting->set(jvSetting.as<double>());
+      } else if (iSetting->isConstChar()) {
+        HomieSetting<const char*>* setting = static_cast<HomieSetting<const char*>*>(iSetting);
+        setting->set(strdup(jvSetting.as<const char*>()));
       }
     }
   }
@@ -306,24 +321,28 @@ bool Config::patch(const char* patch) {
   deserializeJson(configJsonDoc, configJson);
   JsonObject configObject = configJsonDoc.as<JsonObject>();
 
-  // To do alow object that dont currently exist to be added like settings.
-  // if settings wasnt there origionally then it should be allowed to be added by incremental.
-  for (JsonObject::iterator it = patchObject.begin(); it != patchObject.end(); ++it) {
-    if (patchObject[it->key()].is<JsonObject>()) {
-      JsonObject subObject = patchObject[it->key()].as<JsonObject>();
-      for (JsonObject::iterator it2 = subObject.begin(); it2 != subObject.end(); ++it2) {
-        if (!configObject.containsKey(it->key()) || !configObject[it->key()].is<JsonObject>()) {
-          String error = "✖ Config does not contain a ";
-          error.concat(it->key().c_str());
-          error.concat(" object");
-          Interface::get().getLogger() << error << endl;
-          return false;
+  // ToDo: allow patching on a higher depth using recursive functions
+  for (JsonObject::iterator patchRootElement = patchObject.begin(); patchRootElement != patchObject.end(); ++patchRootElement) {
+    if (patchObject[patchRootElement->key()].is<JsonObject>()) {
+      JsonObject patchRootObject = patchObject[patchRootElement->key()];
+      for (JsonObject::iterator patchSubElement = patchRootObject.begin(); patchSubElement != patchRootObject.end(); ++patchSubElement) {
+        JsonVariant configRootElement = configObject[patchSubElement->key()];
+
+        if (!configRootElement.isNull() && configRootElement.is<JsonObject>()) {
+          configRootElement[patchSubElement->key()] = patchSubElement->value();
+        }  // Allow overwriting null objects:
+        else if (configRootElement.isNull() || (configRootElement.is<const char*>() && !configRootElement.as<const char*>())) {
+          configObject[patchRootElement->key()] = patchRootObject;
+        } else {
+            String error = "✖ Config already contains a ";
+            error.concat(patchRootElement->key().c_str());
+            error.concat(" element which is not an object");
+            Interface::get().getLogger() << error << endl;
+            return false;
         }
-        JsonObject subConfigObject = configObject[it->key()].as<JsonObject>();
-        subConfigObject[it2->key()] = it2->value();
       }
     } else {
-      configObject[it->key()] = it->value();
+      configObject[patchRootElement->key()] = patchRootElement->value();
     }
   }
 

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -49,12 +49,13 @@ bool Config::load() {
   configFile.close();
   buf[configSize] = '\0';
 
-  StaticJsonBuffer<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> jsonBuffer;
-  JsonObject& parsedJson = jsonBuffer.parseObject(buf);
-  if (!parsedJson.success()) {
+  StaticJsonDocument<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> jsonDoc;
+  if (deserializeJson(jsonDoc, buf) != DeserializationError::Ok || !jsonDoc.is<JsonObject>()) {
     Interface::get().getLogger() << F("✖ Invalid JSON in the config file") << endl;
     return false;
   }
+
+  JsonObject parsedJson = jsonDoc.as<JsonObject>();
 
   ConfigValidationResult configValidationResult = Validation::validateConfig(parsedJson);
   if (!configValidationResult.valid) {
@@ -77,65 +78,65 @@ bool Config::load() {
   }
 
   const char* reqWifiBssid = "";
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("bssid")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("bssid")) {
     reqWifiBssid = parsedJson["wifi"]["bssid"];
   }
   uint16_t reqWifiChannel = 0;
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("channel")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("channel")) {
     reqWifiChannel = parsedJson["wifi"]["channel"];
   }
   const char* reqWifiIp = "";
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("ip")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("ip")) {
     reqWifiIp = parsedJson["wifi"]["ip"];
   }
   const char* reqWifiMask = "";
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("mask")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("mask")) {
     reqWifiMask = parsedJson["wifi"]["mask"];
   }
   const char* reqWifiGw = "";
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("gw")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("gw")) {
     reqWifiGw = parsedJson["wifi"]["gw"];
   }
   const char* reqWifiDns1 = "";
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("dns1")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("dns1")) {
     reqWifiDns1 = parsedJson["wifi"]["dns1"];
   }
   const char* reqWifiDns2 = "";
-  if (parsedJson["wifi"].as<JsonObject&>().containsKey("dns2")) {
+  if (parsedJson["wifi"].as<JsonObject>().containsKey("dns2")) {
     reqWifiDns2 = parsedJson["wifi"]["dns2"];
   }
 
   uint16_t reqMqttPort = DEFAULT_MQTT_PORT;
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("port")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("port")) {
     reqMqttPort = parsedJson["mqtt"]["port"];
   }
   bool reqMqttSsl = false;
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("ssl")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("ssl")) {
     reqMqttSsl = parsedJson["mqtt"]["ssl"];
   }
   const char* reqMqttFingerprint = "";
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("ssl_fingerprint")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("ssl_fingerprint")) {
     reqMqttFingerprint = parsedJson["mqtt"]["ssl_fingerprint"];
   }
   const char* reqMqttBaseTopic = DEFAULT_MQTT_BASE_TOPIC;
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("base_topic")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("base_topic")) {
     reqMqttBaseTopic = parsedJson["mqtt"]["base_topic"];
   }
   bool reqMqttAuth = false;
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("auth")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("auth")) {
     reqMqttAuth = parsedJson["mqtt"]["auth"];
   }
   const char* reqMqttUsername = "";
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("username")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("username")) {
     reqMqttUsername = parsedJson["mqtt"]["username"];
   }
   const char* reqMqttPassword = "";
-  if (parsedJson["mqtt"].as<JsonObject&>().containsKey("password")) {
+  if (parsedJson["mqtt"].as<JsonObject>().containsKey("password")) {
     reqMqttPassword = parsedJson["mqtt"]["password"];
   }
 
   bool reqOtaEnabled = false;
-  if (parsedJson["ota"].as<JsonObject&>().containsKey("enabled")) {
+  if (parsedJson["ota"].as<JsonObject>().containsKey("enabled")) {
     reqOtaEnabled = parsedJson["ota"]["enabled"];
   }
 
@@ -168,7 +169,7 @@ bool Config::load() {
 
   /* Parse the settings */
 
-  JsonObject& settingsObject = parsedJson["settings"].as<JsonObject&>();
+  JsonObject settingsObject = parsedJson["settings"].as<JsonObject>();
 
   for (IHomieSetting* iSetting : IHomieSetting::settings) {
     if (iSetting->isBool()) {
@@ -211,16 +212,16 @@ char* Config::getSafeConfigFile() const {
   configFile.close();
   buf[configSize] = '\0';
 
-  StaticJsonBuffer<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> jsonBuffer;
-  JsonObject& parsedJson = jsonBuffer.parseObject(buf);
-  parsedJson["wifi"].as<JsonObject&>().remove("password");
-  parsedJson["mqtt"].as<JsonObject&>().remove("username");
-  parsedJson["mqtt"].as<JsonObject&>().remove("password");
+  StaticJsonDocument<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> jsonDoc;
+  deserializeJson(jsonDoc, buf);
+  JsonObject parsedJson = jsonDoc.as<JsonObject>();
+  parsedJson["wifi"].as<JsonObject>().remove("password");
+  parsedJson["mqtt"].as<JsonObject>().remove("username");
+  parsedJson["mqtt"].as<JsonObject>().remove("password");
 
-  size_t jsonBufferLength = parsedJson.measureLength() + 1;
+  size_t jsonBufferLength = measureJson(jsonDoc) + 1;
   std::unique_ptr<char[]> jsonString(new char[jsonBufferLength]);
-  parsedJson.printTo(jsonString.get(), jsonBufferLength);
-
+  serializeJson(jsonDoc, jsonString.get(), jsonBufferLength);
   return strdup(jsonString.get());
 }
 
@@ -262,7 +263,7 @@ HomieBootMode Config::getHomieBootModeOnNextBoot() {
   }
 }
 
-void Config::write(const JsonObject& config) {
+void Config::write(const JsonObject config) {
   if (!_spiffsBegin()) { return; }
 
   SPIFFS.remove(CONFIG_FILE_PATH);
@@ -272,21 +273,21 @@ void Config::write(const JsonObject& config) {
     Interface::get().getLogger() << F("✖ Cannot open config file") << endl;
     return;
   }
-
-  config.printTo(configFile);
+  serializeJson(config, configFile);
   configFile.close();
 }
 
 bool Config::patch(const char* patch) {
   if (!_spiffsBegin()) { return false; }
 
-  StaticJsonBuffer<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> patchJsonBuffer;
-  JsonObject& patchObject = patchJsonBuffer.parseObject(patch);
+  StaticJsonDocument<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> patchJsonDoc;
 
-  if (!patchObject.success()) {
+  if (deserializeJson(patchJsonDoc, patch) != DeserializationError::Ok || !patchJsonDoc.is<JsonObject>()) {
     Interface::get().getLogger() << F("✖ Invalid or too big JSON") << endl;
     return false;
   }
+
+  JsonObject patchObject = patchJsonDoc.as<JsonObject>();
 
   File configFile = SPIFFS.open(CONFIG_FILE_PATH, "r");
   if (!configFile) {
@@ -301,27 +302,28 @@ bool Config::patch(const char* patch) {
   configFile.close();
   configJson[configSize] = '\0';
 
-  StaticJsonBuffer<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> configJsonBuffer;
-  JsonObject& configObject = configJsonBuffer.parseObject(configJson);
+  StaticJsonDocument<MAX_JSON_CONFIG_ARDUINOJSON_BUFFER_SIZE> configJsonDoc;
+  deserializeJson(configJsonDoc, configJson);
+  JsonObject configObject = configJsonDoc.as<JsonObject>();
 
   // To do alow object that dont currently exist to be added like settings.
   // if settings wasnt there origionally then it should be allowed to be added by incremental.
   for (JsonObject::iterator it = patchObject.begin(); it != patchObject.end(); ++it) {
-    if (patchObject[it->key].is<JsonObject&>()) {
-      JsonObject& subObject = patchObject[it->key].as<JsonObject&>();
+    if (patchObject[it->key()].is<JsonObject>()) {
+      JsonObject subObject = patchObject[it->key()].as<JsonObject>();
       for (JsonObject::iterator it2 = subObject.begin(); it2 != subObject.end(); ++it2) {
-        if (!configObject.containsKey(it->key) || !configObject[it->key].is<JsonObject&>()) {
+        if (!configObject.containsKey(it->key()) || !configObject[it->key()].is<JsonObject>()) {
           String error = "✖ Config does not contain a ";
-          error.concat(it->key);
+          error.concat(it->key().c_str());
           error.concat(" object");
           Interface::get().getLogger() << error << endl;
           return false;
         }
-        JsonObject& subConfigObject = configObject[it->key].as<JsonObject&>();
-        subConfigObject[it2->key] = it2->value;
+        JsonObject subConfigObject = configObject[it->key()].as<JsonObject>();
+        subConfigObject[it2->key()] = it2->value();
       }
     } else {
-      configObject[it->key] = it->value;
+      configObject[it->key()] = it->value();
     }
   }
 

--- a/src/Homie/Config.hpp
+++ b/src/Homie/Config.hpp
@@ -27,7 +27,7 @@ class Config {
   void erase();
   void setHomieBootModeOnNextBoot(HomieBootMode bootMode);
   HomieBootMode getHomieBootModeOnNextBoot();
-  void write(const JsonObject& config);
+  void write(const JsonObject config);
   bool patch(const char* patch);
   void log() const;  // print the current config to log output
   bool isValid() const;

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -30,6 +30,10 @@ ConfigValidationResult Validation::_validateConfigRoot(const JsonObject object) 
       result.reason = F("name is not a string");
       return result;
     }
+    if (!jvName.as<const char*>()) {
+      result.reason = F("name is null");
+      return result;
+    }
     if (strlen(jvName.as<const char*>()) + 1 > MAX_FRIENDLY_NAME_LENGTH) {
       result.reason = F("name is too long");
       return result;
@@ -46,6 +50,10 @@ ConfigValidationResult Validation::_validateConfigRoot(const JsonObject object) 
     if (!jvDeviceId.isNull()) {
       if (!jvDeviceId.is<const char*>()) {
         result.reason = F("device_id is not a string");
+        return result;
+      }
+      if (!jvDeviceId.as<const char*>()) {
+        result.reason = F("device_id is null");
         return result;
       }
       if (strlen(jvDeviceId.as<const char*>()) + 1 > MAX_DEVICE_ID_LENGTH) {
@@ -86,6 +94,10 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
       result.reason = F("wifi.ssid is not a string");
       return result;
     }
+    if (!jvWiFiSsid.as<const char*>()) {
+      result.reason = F("wifi.ssid is null");
+      return result;
+    }
     if (strlen(jvWiFiSsid.as<const char*>()) + 1 > MAX_WIFI_SSID_LENGTH) {
       result.reason = F("wifi.ssid is too long");
       return result;
@@ -113,20 +125,26 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
     JsonVariant jvWiFiBssid = jvWiFi["bssid"];
     JsonVariant jvWiFiChannel = jvWiFi["channel"];
 
-    if (!jvWiFiBssid.isNull() && !jvWiFiBssid.is<const char*>()) {
-      result.reason = F("wifi.bssid is not a string");
+    if (!jvWiFiBssid.isNull()) {
+      if (!jvWiFiBssid.is<const char*>()) {
+        result.reason = F("wifi.bssid is not a string");
+        return result;
+      }
+      if (!jvWiFiBssid.as<const char*>()) {
+        result.reason = F("wifi.bssid is null");
+        return result;
+      }
+      if (!Helpers::validateMacAddress(jvWiFiBssid.as<const char*>())) {
+        result.reason = F("wifi.bssid is not valid mac");
+        return result;
+      }
+    }
+    if (!jvWiFiChannel.isNull() && !jvWiFiChannel.is<uint16_t>()) {
+      result.reason = F("wifi.channel is not an integer");
       return result;
     }
     if ((!jvWiFiBssid.isNull() && jvWiFiChannel.isNull()) || (jvWiFiBssid.isNull() && !jvWiFiChannel.isNull())) {
       result.reason = F("wifi.channel_bssid channel and BSSID is required");
-      return result;
-    }
-    if (!jvWiFiBssid.isNull() && !Helpers::validateMacAddress(jvWiFiBssid.as<const char*>())) {
-      result.reason = F("wifi.bssid is not valid mac");
-      return result;
-    }
-    if (!jvWiFiChannel.isNull() && !jvWiFiChannel.is<uint16_t>()) {
-      result.reason = F("wifi.channel is not an integer");
       return result;
     }
   }
@@ -141,6 +159,10 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
         result.reason = F("wifi.ip is not a string");
         return result;
       }
+      if (!jvWiFiIp.as<const char*>()) {
+        result.reason = F("wifi.ip is null");
+        return result;
+      }
       if (strlen(jvWiFiIp.as<const char*>()) + 1 > MAX_IP_STRING_LENGTH) {
         result.reason = F("wifi.ip is too long");
         return result;
@@ -152,8 +174,12 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
     }
 
     if (!jvWiFiMask.isNull()) {
-      if (!jvWiFiMask.isNull() && !jvWiFiMask.is<const char*>()) {
+      if (!jvWiFiMask.is<const char*>()) {
         result.reason = F("wifi.mask is not a string");
+        return result;
+      }
+      if (!jvWiFiMask.as<const char*>()) {
+        result.reason = F("wifi.mask is null");
         return result;
       }
       if (strlen(jvWiFiMask.as<const char*>()) + 1 > MAX_IP_STRING_LENGTH) {
@@ -169,6 +195,10 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
     if (!jvWiFiGateway.isNull()) {
       if (!jvWiFiGateway.is<const char*>()) {
         result.reason = F("wifi.gw is not a string");
+        return result;
+      }
+      if (!jvWiFiGateway.as<const char*>()) {
+        result.reason = F("wifi.gw is null");
         return result;
       }
       if (strlen(jvWiFiGateway.as<const char*>()) + 1 > MAX_IP_STRING_LENGTH) {
@@ -198,6 +228,10 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
         result.reason = F("wifi.dns1 is not a string");
         return result;
       }
+      if (!jvWiFiDns1.as<const char*>()) {
+        result.reason = F("wifi.dns1 is null");
+        return result;
+      }
       if (strlen(jvWiFiDns1.as<const char*>()) + 1 > MAX_IP_STRING_LENGTH) {
         result.reason = F("wifi.dns1 is too long");
         return result;
@@ -215,6 +249,10 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
       }
       if (!jvWiFiDns2.is<const char*>()) {
         result.reason = F("wifi.dns2 is not a string");
+        return result;
+      }
+      if (!jvWiFiDns2.as<const char*>()) {
+        result.reason = F("wifi.dns2 is null");
         return result;
       }
       if (strlen(jvWiFiDns2.as<const char*>()) + 1 > MAX_IP_STRING_LENGTH) {
@@ -248,6 +286,10 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject object) 
 
     if (!jvMqttHost.is<const char*>()) {
       result.reason = F("mqtt.host is not a string");
+      return result;
+    }
+    if (!jvMqttHost.as<const char*>()) {
+      result.reason = F("mqtt.host is null");
       return result;
     }
     if (strlen(jvMqttHost.as<const char*>()) + 1 > MAX_HOSTNAME_LENGTH) {
@@ -286,7 +328,10 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject object) 
         result.reason = F("mqtt.ssl_fingerprint is not a string");
         return result;
       }
-
+      if (!jvMqttSslFingerprint.as<const char*>()) {
+        result.reason = F("mqtt.ssl_fingerprint is null");
+        return result;
+      }
       if (strlen(jvMqttSslFingerprint.as<const char*>()) > MAX_FINGERPRINT_SIZE * 2) {
         result.reason = F("mqtt.ssl_fingerprint is too long");
         return result;
@@ -300,6 +345,10 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject object) 
     if (!jvMqttBaseTopic.isNull()) {
       if (!jvMqttBaseTopic.is<const char*>()) {
         result.reason = F("mqtt.base_topic is not a string");
+        return result;
+      }
+      if (!jvMqttBaseTopic.as<const char*>()) {
+        result.reason = F("mqtt.base_topic is null");
         return result;
       }
       if (strlen(jvMqttBaseTopic.as<const char*>()) + 1 > MAX_MQTT_BASE_TOPIC_LENGTH) {
@@ -325,12 +374,20 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject object) 
           result.reason = F("mqtt.username is not a string");
           return result;
         }
+        if (!jvMqttUsername.as<const char*>()) {
+          result.reason = F("mqtt.username is null");
+          return result;
+        }
         if (strlen(jvMqttUsername.as<const char*>()) + 1 > MAX_MQTT_CREDS_LENGTH) {
           result.reason = F("mqtt.username is too long");
           return result;
         }
         if (!jvMqttPassword.is<const char*>()) {
           result.reason = F("mqtt.password is not a string");
+          return result;
+        }
+        if (!jvMqttPassword.as<const char*>()) {
+          result.reason = F("mqtt.password is null");
           return result;
         }
         if (strlen(jvMqttPassword.as<const char*>()) + 1 > MAX_MQTT_CREDS_LENGTH) {
@@ -379,8 +436,13 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject obje
 
   JsonVariant jvSettings = object["settings"];
 
-  if (jvSettings.is<JsonObject>()) {
-    settingsObject =jvSettings.as<JsonObject>();
+  if (!jvSettings.isNull()) {
+    if (jvSettings.is<JsonObject>()) {
+      settingsObject = jvSettings.as<JsonObject>();
+    } else {
+      result.reason = F("settings is not an object");
+      return result;
+    }
   }
 
   if (settingsObject.size() > MAX_CONFIG_SETTING_SIZE) {//max settings here and in isettings

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -2,7 +2,7 @@
 
 using namespace HomieInternals;
 
-ConfigValidationResult Validation::validateConfig(const JsonObject& object) {
+ConfigValidationResult Validation::validateConfig(const JsonObject object) {
   ConfigValidationResult result;
   result = _validateConfigRoot(object);
   if (!result.valid) return result;
@@ -19,7 +19,7 @@ ConfigValidationResult Validation::validateConfig(const JsonObject& object) {
   return result;
 }
 
-ConfigValidationResult Validation::_validateConfigRoot(const JsonObject& object) {
+ConfigValidationResult Validation::_validateConfigRoot(const JsonObject object) {
   ConfigValidationResult result;
   result.valid = false;
   if (!object.containsKey("name") || !object["name"].is<const char*>()) {
@@ -57,15 +57,15 @@ ConfigValidationResult Validation::_validateConfigRoot(const JsonObject& object)
   return result;
 }
 
-ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object) {
+ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) {
   ConfigValidationResult result;
   result.valid = false;
 
-  if (!object.containsKey("wifi") || !object["wifi"].is<JsonObject&>()) {
+  if (!object.containsKey("wifi") || !object["wifi"].is<JsonObject>()) {
     result.reason = F("wifi is not an object");
     return result;
   }
-  if (!object["wifi"].as<JsonObject&>().containsKey("ssid") || !object["wifi"]["ssid"].is<const char*>()) {
+  if (!object["wifi"].as<JsonObject>().containsKey("ssid") || !object["wifi"]["ssid"].is<const char*>()) {
     result.reason = F("wifi.ssid is not a string");
     return result;
   }
@@ -73,7 +73,7 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.ssid is too long");
     return result;
   }
-  if (!object["wifi"].as<JsonObject&>().containsKey("password") || !object["wifi"]["password"].is<const char*>()) {
+  if (!object["wifi"].as<JsonObject>().containsKey("password") || !object["wifi"]["password"].is<const char*>()) {
     result.reason = F("wifi.password is not a string");
     return result;
   }
@@ -82,24 +82,24 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     return result;
   }
   // by benzino
-  if (object["wifi"].as<JsonObject&>().containsKey("bssid") && !object["wifi"]["bssid"].is<const char*>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("bssid") && !object["wifi"]["bssid"].is<const char*>()) {
     result.reason = F("wifi.bssid is not a string");
     return result;
   }
-  if ((object["wifi"].as<JsonObject&>().containsKey("bssid") && !object["wifi"].as<JsonObject&>().containsKey("channel")) ||
-    (!object["wifi"].as<JsonObject&>().containsKey("bssid") && object["wifi"].as<JsonObject&>().containsKey("channel"))) {
+  if ((object["wifi"].as<JsonObject>().containsKey("bssid") && !object["wifi"].as<JsonObject>().containsKey("channel")) ||
+    (!object["wifi"].as<JsonObject>().containsKey("bssid") && object["wifi"].as<JsonObject>().containsKey("channel"))) {
     result.reason = F("wifi.channel_bssid channel and BSSID is required");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("bssid") && !Helpers::validateMacAddress(object["wifi"].as<JsonObject&>().get<const char*>("bssid"))) {
+  if (object["wifi"].as<JsonObject>().containsKey("bssid") && !Helpers::validateMacAddress(object["wifi"].as<JsonObject>().getMember("bssid").as<const char*>())) {
     result.reason = F("wifi.bssid is not valid mac");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("channel") && !object["wifi"]["channel"].is<uint16_t>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("channel") && !object["wifi"]["channel"].is<uint16_t>()) {
     result.reason = F("wifi.channel is not an integer");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("ip") && !object["wifi"]["ip"].is<const char*>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("ip") && !object["wifi"]["ip"].is<const char*>()) {
     result.reason = F("wifi.ip is not a string");
     return result;
   }
@@ -107,11 +107,11 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.ip is too long");
     return result;
   }
-  if (object["wifi"]["ip"] && !Helpers::validateIP(object["wifi"].as<JsonObject&>().get<const char*>("ip"))) {
+  if (object["wifi"]["ip"] && !Helpers::validateIP(object["wifi"].as<JsonObject>().getMember("ip").as<const char*>())) {
     result.reason = F("wifi.ip is not valid ip address");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("mask") && !object["wifi"]["mask"].is<const char*>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("mask") && !object["wifi"]["mask"].is<const char*>()) {
     result.reason = F("wifi.mask is not a string");
     return result;
   }
@@ -119,11 +119,11 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.mask is too long");
     return result;
   }
-  if (object["wifi"]["mask"] && !Helpers::validateIP(object["wifi"].as<JsonObject&>().get<const char*>("mask"))) {
+  if (object["wifi"]["mask"] && !Helpers::validateIP(object["wifi"].as<JsonObject>().getMember("mask").as<const char*>())) {
     result.reason = F("wifi.mask is not valid mask");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("gw") && !object["wifi"]["gw"].is<const char*>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("gw") && !object["wifi"]["gw"].is<const char*>()) {
     result.reason = F("wifi.gw is not a string");
     return result;
   }
@@ -131,17 +131,17 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.gw is too long");
     return result;
   }
-  if (object["wifi"]["gw"] && !Helpers::validateIP(object["wifi"].as<JsonObject&>().get<const char*>("gw"))) {
+  if (object["wifi"]["gw"] && !Helpers::validateIP(object["wifi"].as<JsonObject>().getMember("gw").as<const char*>())) {
     result.reason = F("wifi.gw is not valid gateway address");
     return result;
   }
-  if ((object["wifi"].as<JsonObject&>().containsKey("ip") && (!object["wifi"].as<JsonObject&>().containsKey("mask") || !object["wifi"].as<JsonObject&>().containsKey("gw"))) ||
-    (object["wifi"].as<JsonObject&>().containsKey("gw") && (!object["wifi"].as<JsonObject&>().containsKey("mask") || !object["wifi"].as<JsonObject&>().containsKey("ip"))) ||
-    (object["wifi"].as<JsonObject&>().containsKey("mask") && (!object["wifi"].as<JsonObject&>().containsKey("ip") || !object["wifi"].as<JsonObject&>().containsKey("gw")))) {
+  if ((object["wifi"].as<JsonObject>().containsKey("ip") && (!object["wifi"].as<JsonObject>().containsKey("mask") || !object["wifi"].as<JsonObject>().containsKey("gw"))) ||
+    (object["wifi"].as<JsonObject>().containsKey("gw") && (!object["wifi"].as<JsonObject>().containsKey("mask") || !object["wifi"].as<JsonObject>().containsKey("ip"))) ||
+    (object["wifi"].as<JsonObject>().containsKey("mask") && (!object["wifi"].as<JsonObject>().containsKey("ip") || !object["wifi"].as<JsonObject>().containsKey("gw")))) {
     result.reason = F("wifi.staticip ip, gw and mask is required");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("dns1") && !object["wifi"]["dns1"].is<const char*>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("dns1") && !object["wifi"]["dns1"].is<const char*>()) {
     result.reason = F("wifi.dns1 is not a string");
     return result;
   }
@@ -149,15 +149,15 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.dns1 is too long");
     return result;
   }
-  if (object["wifi"]["dns1"] && !Helpers::validateIP(object["wifi"].as<JsonObject&>().get<const char*>("dns1"))) {
+  if (object["wifi"]["dns1"] && !Helpers::validateIP(object["wifi"].as<JsonObject>().getMember("dns1").as<const char*>())) {
     result.reason = F("wifi.dns1 is not valid dns address");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("dns2") && !object["wifi"].as<JsonObject&>().containsKey("dns1")) {
+  if (object["wifi"].as<JsonObject>().containsKey("dns2") && !object["wifi"].as<JsonObject>().containsKey("dns1")) {
     result.reason = F("wifi.dns2 no dns1 defined");
     return result;
   }
-  if (object["wifi"].as<JsonObject&>().containsKey("dns2") && !object["wifi"]["dns2"].is<const char*>()) {
+  if (object["wifi"].as<JsonObject>().containsKey("dns2") && !object["wifi"]["dns2"].is<const char*>()) {
     result.reason = F("wifi.dns2 is not a string");
     return result;
   }
@@ -165,7 +165,7 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
     result.reason = F("wifi.dns2 is too long");
     return result;
   }
-  if (object["wifi"]["dns2"] && !Helpers::validateIP(object["wifi"].as<JsonObject&>().get<const char*>("dns2"))) {
+  if (object["wifi"]["dns2"] && !Helpers::validateIP(object["wifi"].as<JsonObject>().getMember("dns2").as<const char*>())) {
     result.reason = F("wifi.dns2 is not valid dns address");
     return result;
   }
@@ -180,15 +180,15 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject& object)
   return result;
 }
 
-ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object) {
+ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject object) {
   ConfigValidationResult result;
   result.valid = false;
 
-  if (!object.containsKey("mqtt") || !object["mqtt"].is<JsonObject&>()) {
+  if (!object.containsKey("mqtt") || !object["mqtt"].is<JsonObject>()) {
     result.reason = F("mqtt is not an object");
     return result;
   }
-  if (!object["mqtt"].as<JsonObject&>().containsKey("host") || !object["mqtt"]["host"].is<const char*>()) {
+  if (!object["mqtt"].as<JsonObject>().containsKey("host") || !object["mqtt"]["host"].is<const char*>()) {
     result.reason = F("mqtt.host is not a string");
     return result;
   }
@@ -196,17 +196,17 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object)
     result.reason = F("mqtt.host is too long");
     return result;
   }
-  if (object["mqtt"].as<JsonObject&>().containsKey("port") && !object["mqtt"]["port"].is<uint16_t>()) {
+  if (object["mqtt"].as<JsonObject>().containsKey("port") && !object["mqtt"]["port"].is<uint16_t>()) {
     result.reason = F("mqtt.port is not an integer");
     return result;
   }
-  if (object["mqtt"].as<JsonObject&>().containsKey("ssl")) {
+  if (object["mqtt"].as<JsonObject>().containsKey("ssl")) {
     if (!object["mqtt"]["ssl"].is<bool>()) {
       result.reason = F("mqtt.ssl is not a bool");
       return result;
     }
   }
-  if (object["mqtt"].as<JsonObject&>().containsKey("ssl_fingerprint")) {
+  if (object["mqtt"].as<JsonObject>().containsKey("ssl_fingerprint")) {
     if (!object["mqtt"]["ssl_fingerprint"].is<const char*>()) {
       result.reason = F("mqtt.ssl_fingerprint is not a string");
       return result;
@@ -217,7 +217,7 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object)
       return result;
     }
   }
-  if (object["mqtt"].as<JsonObject&>().containsKey("base_topic")) {
+  if (object["mqtt"].as<JsonObject>().containsKey("base_topic")) {
     if (!object["mqtt"]["base_topic"].is<const char*>()) {
       result.reason = F("mqtt.base_topic is not a string");
       return result;
@@ -228,14 +228,14 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object)
       return result;
     }
   }
-  if (object["mqtt"].as<JsonObject&>().containsKey("auth")) {
+  if (object["mqtt"].as<JsonObject>().containsKey("auth")) {
     if (!object["mqtt"]["auth"].is<bool>()) {
       result.reason = F("mqtt.auth is not a boolean");
       return result;
     }
 
     if (object["mqtt"]["auth"]) {
-      if (!object["mqtt"].as<JsonObject&>().containsKey("username") || !object["mqtt"]["username"].is<const char*>()) {
+      if (!object["mqtt"].as<JsonObject>().containsKey("username") || !object["mqtt"]["username"].is<const char*>()) {
         result.reason = F("mqtt.username is not a string");
         return result;
       }
@@ -243,7 +243,7 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object)
         result.reason = F("mqtt.username is too long");
         return result;
       }
-      if (!object["mqtt"].as<JsonObject&>().containsKey("password") || !object["mqtt"]["password"].is<const char*>()) {
+      if (!object["mqtt"].as<JsonObject>().containsKey("password") || !object["mqtt"]["password"].is<const char*>()) {
         result.reason = F("mqtt.password is not a string");
         return result;
       }
@@ -264,15 +264,15 @@ ConfigValidationResult Validation::_validateConfigMqtt(const JsonObject& object)
   return result;
 }
 
-ConfigValidationResult Validation::_validateConfigOta(const JsonObject& object) {
+ConfigValidationResult Validation::_validateConfigOta(const JsonObject object) {
   ConfigValidationResult result;
   result.valid = false;
 
-  if (!object.containsKey("ota") || !object["ota"].is<JsonObject&>()) {
+  if (!object.containsKey("ota") || !object["ota"].is<JsonObject>()) {
     result.reason = F("ota is not an object");
     return result;
   }
-  if (!object["ota"].as<JsonObject&>().containsKey("enabled") || !object["ota"]["enabled"].is<bool>()) {
+  if (!object["ota"].as<JsonObject>().containsKey("enabled") || !object["ota"]["enabled"].is<bool>()) {
     result.reason = F("ota.enabled is not a boolean");
     return result;
   }
@@ -281,19 +281,19 @@ ConfigValidationResult Validation::_validateConfigOta(const JsonObject& object) 
   return result;
 }
 
-ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& object) {
+ConfigValidationResult Validation::_validateConfigSettings(const JsonObject object) {
   ConfigValidationResult result;
   result.valid = false;
 
-  StaticJsonBuffer<0> emptySettingsBuffer;
+  StaticJsonDocument<0> emptySettingsDoc;
 
-  JsonObject* settingsObject = &(emptySettingsBuffer.createObject());
+  JsonObject settingsObject = emptySettingsDoc.to<JsonObject>();
 
-  if (object.containsKey("settings") && object["settings"].is<JsonObject&>()) {
-    settingsObject = &(object["settings"].as<JsonObject&>());
+  if (object.containsKey("settings") && object["settings"].is<JsonObject>()) {
+    settingsObject = object["settings"].as<JsonObject>();
   }
 
-  if (settingsObject->size() > MAX_CONFIG_SETTING_SIZE) {//max settings here and in isettings
+  if (settingsObject.size() > MAX_CONFIG_SETTING_SIZE) {//max settings here and in isettings
     result.reason = F("settings contains more elements than the set limit");
     return result;
   }
@@ -321,11 +321,11 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& obj
     if (iSetting->isBool()) {
       HomieSetting<bool>* setting = static_cast<HomieSetting<bool>*>(iSetting);
 
-      if (settingsObject->containsKey(setting->getName())) {
-        if (!(*settingsObject)[setting->getName()].is<bool>()) {
+      if (settingsObject.containsKey(setting->getName())) {
+        if (!settingsObject[setting->getName()].is<bool>()) {
           setReason(Issue::Type);
           return result;
-        } else if (!setting->validate((*settingsObject)[setting->getName()].as<bool>())) {
+        } else if (!setting->validate(settingsObject[setting->getName()].as<bool>())) {
           setReason(Issue::Validator);
           return result;
         }
@@ -336,11 +336,11 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& obj
     } else if (iSetting->isLong()) {
       HomieSetting<long>* setting = static_cast<HomieSetting<long>*>(iSetting);
 
-      if (settingsObject->containsKey(setting->getName())) {
-        if (!(*settingsObject)[setting->getName()].is<long>()) {
+      if (settingsObject.containsKey(setting->getName())) {
+        if (!settingsObject[setting->getName()].is<long>()) {
           setReason(Issue::Type);
           return result;
-        } else if (!setting->validate((*settingsObject)[setting->getName()].as<long>())) {
+        } else if (!setting->validate(settingsObject[setting->getName()].as<long>())) {
           setReason(Issue::Validator);
           return result;
         }
@@ -351,11 +351,11 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& obj
     } else if (iSetting->isDouble()) {
       HomieSetting<double>* setting = static_cast<HomieSetting<double>*>(iSetting);
 
-      if (settingsObject->containsKey(setting->getName())) {
-        if (!(*settingsObject)[setting->getName()].is<double>()) {
+      if (settingsObject.containsKey(setting->getName())) {
+        if (!settingsObject[setting->getName()].is<double>()) {
           setReason(Issue::Type);
           return result;
-        } else if (!setting->validate((*settingsObject)[setting->getName()].as<double>())) {
+        } else if (!setting->validate(settingsObject[setting->getName()].as<double>())) {
           setReason(Issue::Validator);
           return result;
         }
@@ -366,11 +366,11 @@ ConfigValidationResult Validation::_validateConfigSettings(const JsonObject& obj
     } else if (iSetting->isConstChar()) {
       HomieSetting<const char*>* setting = static_cast<HomieSetting<const char*>*>(iSetting);
 
-      if (settingsObject->containsKey(setting->getName())) {
-        if (!(*settingsObject)[setting->getName()].is<const char*>()) {
+      if (settingsObject.containsKey(setting->getName())) {
+        if (!settingsObject[setting->getName()].is<const char*>()) {
           setReason(Issue::Type);
           return result;
-        } else if (!setting->validate((*settingsObject)[setting->getName()].as<const char*>())) {
+        } else if (!setting->validate(settingsObject[setting->getName()].as<const char*>())) {
           setReason(Issue::Validator);
           return result;
         }

--- a/src/Homie/Utils/Validation.hpp
+++ b/src/Homie/Utils/Validation.hpp
@@ -15,13 +15,13 @@ struct ConfigValidationResult {
 
 class Validation {
  public:
-  static ConfigValidationResult validateConfig(const JsonObject& object);
+  static ConfigValidationResult validateConfig(const JsonObject object);
 
  private:
-  static ConfigValidationResult _validateConfigRoot(const JsonObject& object);
-  static ConfigValidationResult _validateConfigWifi(const JsonObject& object);
-  static ConfigValidationResult _validateConfigMqtt(const JsonObject& object);
-  static ConfigValidationResult _validateConfigOta(const JsonObject& object);
-  static ConfigValidationResult _validateConfigSettings(const JsonObject& object);
+  static ConfigValidationResult _validateConfigRoot(const JsonObject object);
+  static ConfigValidationResult _validateConfigWifi(const JsonObject object);
+  static ConfigValidationResult _validateConfigMqtt(const JsonObject object);
+  static ConfigValidationResult _validateConfigOta(const JsonObject object);
+  static ConfigValidationResult _validateConfigSettings(const JsonObject object);
 };
 }  // namespace HomieInternals


### PR DESCRIPTION
Migrates the code of develop-v3 from ArduinoJson v5 to v6.

I tested this patch on ESP32 and haven't encountered any issues except the [JSON example configuration](https://github.com/homieiot/homie-esp8266/blob/develop-v3/docs/configuration/json-configuration-file.md) not being able to be loaded because it is too big as it is duplicated by ArduinoJson.

I'd recommend someone to test this patch / the branch on my repo on ESP8266 first before merging since I don't have one available.