### PR TITLE
Add workaround for AP crash issues on ESP32

### DIFF
--- a/src/Homie/Boot/Boot.cpp
+++ b/src/Homie/Boot/Boot.cpp
@@ -13,7 +13,11 @@ void Boot::setup() {
     digitalWrite(Interface::get().led.pin, !Interface::get().led.on);
   }
 
+  #ifdef ESP32
+  WiFi.persistent(false); // Workaround for ESP32: Disable Wi-Fi persistence to prevent crashes on AP connect
+  #else
   WiFi.persistent(true);  // Persist data on SDK as it seems Wi-Fi connection is faster
+  #endif //ESP32
 
   Interface::get().getLogger() << F("💡 Firmware ") << Interface::get().firmware.name << F(" (") << Interface::get().firmware.version << F(")") << endl;
   Interface::get().getLogger() << F("🔌 Booting into ") << _name << F(" mode 🔌") << endl;


### PR DESCRIPTION
This is a workaround for issue #588. Disabling WiFi persistence will stop the crashes from occuring, as long as no other firmware with WiFi persistence has been ran on the ESP32 prior. In this case the internal flash needs to be wiped beforehand.