### PR TITLE
added dependencies for ldf mode off

### DIFF
--- a/library.json
+++ b/library.json
@@ -34,6 +34,16 @@
     },
     {
       "name": "ESP Async WebServer"
+    },
+    {
+      "name": "Ticker",
+      "version": "1.0"
+    },
+    {
+      "name": "ESP8266HTTPClient"
+    },
+    {
+      "name": "DNSServer"
     }
   ],
   "export": {


### PR DESCRIPTION
To be more precise with library dependencies I turned the PlatformIO `lib_ldf_mode=off`. This requires then definition of all required libraries.