### PR TITLE
getSketchMD5() at BootNormal constructor crashes on ESP32 (#641)

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -21,9 +21,7 @@ BootNormal::BootNormal()
   , _mqttPayloadBuffer(nullptr)
   , _mqttTopicLevels(nullptr)
   , _mqttTopicLevelsCount(0)
-  , _mqttTopicCopy(nullptr)
-  {strlcpy(_fwChecksum, ESP.getSketchMD5().c_str(), sizeof(_fwChecksum));
-  _fwChecksum[sizeof(_fwChecksum) - 1] = '\0';
+  , _mqttTopicCopy(nullptr) {
 }
 
 BootNormal::~BootNormal() {


### PR DESCRIPTION

Removed the lines copying the sketch MD5 at the BootNormal constructor
since that crashed the firmware. At that point the ESP object is not ready
to invoke getSketchMD5(). Also the code was duplicated since it's was
already invoked at the BootNormal::setup function with no issues.