### PR TITLE
Fix semicolon after define statement in LightOnOff example

### DIFF
--- a/examples/LightOnOff/LightOnOff.ino
+++ b/examples/LightOnOff/LightOnOff.ino
@@ -1,6 +1,6 @@
 #include <Homie.h>
 
-#define firmwareVersion "1.0.0";
+#define firmwareVersion "1.0.0"
 const int PIN_RELAY = 5;
 
 HomieNode lightNode("light", "Light", "switch");


### PR DESCRIPTION
Closes #639 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>
