### PR TITLE
Fix topic copying for chunked messages

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -781,13 +781,14 @@ void BootNormal::_onMqttDisconnected(AsyncMqttClientDisconnectReason reason) {
 void BootNormal::_onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
   if (total == 0) return;  // no empty message possible
 
-  size_t topicLength = strlen(topic);
-  _mqttTopicCopy = std::unique_ptr<char[]>(new char[topicLength+1]);
-  memcpy(_mqttTopicCopy.get(), topic, topicLength);
-  _mqttTopicCopy.get()[topicLength] = '\0';
-
-  // split topic on each "/"
   if (index == 0) {
+    // Copy the topic
+    size_t topicLength = strlen(topic);
+    _mqttTopicCopy = std::unique_ptr<char[]>(new char[topicLength+1]);
+    memcpy(_mqttTopicCopy.get(), topic, topicLength);
+    _mqttTopicCopy.get()[topicLength] = '\0';
+
+    // Split the topic copy on each "/"
     __splitTopic(_mqttTopicCopy.get());
   }
 


### PR DESCRIPTION
Only copy the topic on the first message chunk. Otherwise the old copy will be
destroyed on subsequent calls to `_onMqttMessage()` for the same message, while
the copy is still being referenced by `_mqttTopicLevels`. This leads to undefined
behaviour.

Should solve #644 

Thanks @nemidiy for investigating this issue!