### PR TITLE
fixed wrong WiFi DNS parsing of commit 2093ce8665366ce056d5ee5894e52c…

### DIFF
--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -190,7 +190,7 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
     JsonVariant wifiDns2 = wifi["dns2"];
 
     if (!wifiDns1.isNull()) {
-      if (wifiDns1.as<const char*>()) {
+      if (!wifiDns1.as<const char*>()) {
         result.reason = F("wifi.dns1 is not a string");
         return result;
       }
@@ -204,7 +204,7 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
       }
     }
     if (!wifiDns2.isNull()) {
-      if (wifiDns2.as<const char*>()) {
+      if (!wifiDns2.as<const char*>()) {
         result.reason = F("wifi.dns2 is not a string");
         return result;
       }


### PR DESCRIPTION
 of commit 2093ce8665366ce056d5ee5894e52c3445287233.
Pull request 627 introduces optimized JSON code but reading dns1 and dns2 from the configuration was wrong in this code. This pull request fixes that.