### PR TITLE
Various code optimizations

### DIFF
--- a/src/Homie/Boot/BootConfig.cpp
+++ b/src/Homie/Boot/BootConfig.cpp
@@ -131,8 +131,13 @@ void BootConfig::_onWifiConnectRequest(AsyncWebServerRequest *request) {
   JsonObject parsedJson = parseJsonDoc.as<JsonObject>();
   JsonVariant wifiSsid = parsedJson["ssid"];
   JsonVariant wifiPassword = parsedJson["password"];
-  if (!wifiSsid.as<const char*>() || !wifiPassword.is<const char*>()) {
-    __SendJSONError(request, F("✖ SSID and password required"));
+  if (!wifiSsid.as<const char*>()) {
+    __SendJSONError(request, F("✖ SSID required"));
+    return;
+  }
+
+  if (!wifiPassword.isNull() && !wifiPassword.is<const char*>()) {
+    __SendJSONError(request, F("✖ Password is not a string"));
     return;
   }
 

--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -472,7 +472,7 @@ void BootNormal::_advertise() {
     {
       char* safeConfigFile = Interface::get().getConfig().getSafeConfigFile();
       packetId = Interface::get().getMqttClient().publish(_prefixMqttTopic(PSTR("/$implementation/config")), 1, true, safeConfigFile);
-      free(safeConfigFile);
+      delete safeConfigFile;
       if (packetId != 0) _advertisementProgress.globalStep = AdvertisementProgress::GlobalStep::PUB_IMPLEMENTATION_VERSION;
       break;
     }

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -68,7 +68,6 @@ bool Config::load() {
 
   const char* reqName = parsedJson["name"];
   const char* reqWifiSsid = reqWifi["ssid"];
-  const char* reqWifiPassword = reqWifi["password"];
   const char* reqMqttHost = reqMqtt["host"];
 
   /* Optional config items */
@@ -78,6 +77,7 @@ bool Config::load() {
 
   uint16_t reqWifiChannel = reqWifi["channel"] | 0;
   const char* reqWifiBssid = reqWifi["bssid"] | "";
+  const char* reqWifiPassword = reqWifi["password"]; // implicit | nullptr;
   const char* reqWifiIp = reqWifi["ip"] | "";
   const char* reqWifiMask = reqWifi["mask"] | "";
   const char* reqWifiGw = reqWifi["gw"] | "";

--- a/src/Homie/Config.cpp
+++ b/src/Homie/Config.cpp
@@ -164,9 +164,9 @@ char* Config::getSafeConfigFile() const {
   parsedJson["mqtt"].as<JsonObject>().remove("password");
 
   size_t jsonBufferLength = measureJson(jsonDoc) + 1;
-  std::unique_ptr<char[]> jsonString(new char[jsonBufferLength]);
-  serializeJson(jsonDoc, jsonString.get(), jsonBufferLength);
-  return strdup(jsonString.get());
+  char* jsonString = new char[jsonBufferLength];
+  serializeJson(jsonDoc, jsonString, jsonBufferLength);
+  return jsonString;
 }
 
 void Config::erase() {

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -345,17 +345,19 @@ ConfigValidationResult Validation::_validateConfigOta(const JsonObject object) {
 
   JsonVariant ota = object["ota"];
 
-  if (!ota.is<JsonObject>()) {
-    result.reason = F("ota is not an object");
-    return result;
-  }
-
-  {
-    JsonVariant otaEnabled = ota["enabled"];
-
-    if (!otaEnabled.is<bool>()) {
-      result.reason = F("ota.enabled is not a boolean");
+  if (!ota.isNull()) {
+    if (!ota.is<JsonObject>()) {
+      result.reason = F("ota is not an object");
       return result;
+    }
+
+    {
+      JsonVariant otaEnabled = ota["enabled"];
+
+      if (!otaEnabled.isNull() && !otaEnabled.is<bool>()) {
+        result.reason = F("ota.enabled is not a boolean");
+        return result;
+      }
     }
   }
 

--- a/src/Homie/Utils/Validation.cpp
+++ b/src/Homie/Utils/Validation.cpp
@@ -102,13 +102,15 @@ ConfigValidationResult Validation::_validateConfigWifi(const JsonObject object) 
   {
     JsonVariant wifiPassword = wifi["password"];
 
-    if (!wifiPassword.is<const char*>()) {
-      result.reason = F("wifi.password is not a string");
-      return result;
-    }
-    if (wifiPassword.as<const char*>() && strlen(wifiPassword.as<const char*>()) + 1 > MAX_WIFI_PASSWORD_LENGTH) {
-      result.reason = F("wifi.password is too long");
-      return result;
+    if (!wifiPassword.isNull()) {
+      if (!wifiPassword.as<const char*>()) {
+        result.reason = F("wifi.password is not a string");
+        return result;
+      }
+      if (strlen(wifiPassword.as<const char*>()) + 1 > MAX_WIFI_PASSWORD_LENGTH) {
+        result.reason = F("wifi.password is too long");
+        return result;
+      }
     }
   }
 


### PR DESCRIPTION
- In the migration to ArduinoJson v6 I've introduced a bug disallowing the usage of `null` as `wifi.password`. Commit 25f6b8c fixes this.
- The parameter `ota.enabled` was treated as optional in the config load code, but not in the validation code. Commit 64ca0ba will make `ota.enabled` optional and default to disabled OTA.
- In Config::getSafeConfigFile(), a `char[]` buffer gets allocated within a `unique_ptr`, only to be copied and and then discarded at the end of the method. Commit 60ca263  removes this unnecessary step.