### PR TITLE
Fix #589: ota-updater.py for V2 and V3 devices

### DIFF
--- a/scripts/ota_updater/ota_updater.py
+++ b/scripts/ota_updater/ota_updater.py
@@ -13,7 +13,9 @@ def on_connect(client, userdata, flags, rc):
     else:
         print("Connected with result code {}".format(rc))
 
-    client.subscribe("{base_topic}{device_id}/$state".format(**userdata))
+    client.subscribe("{base_topic}{device_id}/$state".format(**userdata))  # v3 / v4 devices
+    client.subscribe("{base_topic}{device_id}/$online".format(**userdata))  # v2 devices
+
 
     print("Waiting for device to come online...")
 
@@ -66,8 +68,8 @@ def on_message(client, userdata, msg):
             print("Device ota disabled, aborting...")
             client.disconnect()
 
-    elif msg.topic.endswith('$state'):
-        if msg.payload == 'false':
+    elif msg.topic.endswith('$state') or msg.topic.endswith('$online'):
+        if (msg.topic.endswith('$state') and msg.payload != 'ready') or (msg.topic.endswith('$online') and msg.payload == 'false'): 
             return
 
         # calcluate firmware md5


### PR DESCRIPTION
One line to fix both problems mentioned in #589:

Checking the "$state" topic for not "false" was wrong, because since v3
the online state must be "ready" to continue.

Thus, also in "init" state the ota-updater re-subscribed to the $fw
topic and thus got old retained checksum from broker. (The homie device
usually has not sent the new $fw/checksum at this moment).

Now the script uses the firmware MD5 only if it has been sent from a
"ready" device (or $online != false device to support v2.x devices).