### PR TITLE
Closes: #652; doDeepSleep: changed the datatype of time_us to uint64_t

### DIFF
--- a/docs/others/cpp-api-reference.md
+++ b/docs/others/cpp-api-reference.md
@@ -179,7 +179,7 @@ void prepareToSleep();
 Prepare the device for deep sleep. It ensures messages are sent and disconnects cleanly from the MQTT broker, triggering a `READY_TO_SLEEP` event when done.
 
 ```c++
-void doDeepSleep(uint32_t time_us = 0, RFMode mode = RF_DEFAULT);
+void doDeepSleep(uint64_t time_us = 0, RFMode mode = RF_DEFAULT);
 ```
 
 Puth the device into deep sleep. It ensures the Serial is flushed.

--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -369,7 +369,7 @@ void HomieClass::prepareToSleep() {
   }
 }
 
-void HomieClass::doDeepSleep(uint32_t time_us, RFMode mode) {
+void HomieClass::doDeepSleep(uint64_t time_us, RFMode mode) {
   Interface::get().getLogger() << F("💤 Device is deep sleeping...") << endl;
   Serial.flush();
   ESP.deepSleep(time_us, mode);

--- a/src/Homie.hpp
+++ b/src/Homie.hpp
@@ -68,7 +68,7 @@ class HomieClass {
   //FIXME implement on ESP32
   #elif defined(ESP8266)
   static void prepareToSleep();
-  static void doDeepSleep(uint32_t time_us = 0, RFMode mode = RF_DEFAULT);
+  static void doDeepSleep(uint64_t time_us = 0, RFMode mode = RF_DEFAULT);
   #endif // ESP32
 
  private:


### PR DESCRIPTION
doDeepSleep: changed the datatype of time_us to uint64_t, according to ESP8266 Arduino core 2.4.1

As a result it is possible to set durations longer than ~71min.