### PR TITLE
Enable LED feedback when LED pin is set

### DIFF
--- a/src/Homie.cpp
+++ b/src/Homie.cpp
@@ -210,6 +210,7 @@ HomieClass& HomieClass::setLedPin(uint8_t pin, uint8_t on) {
 
   Interface::get().led.pin = pin;
   Interface::get().led.on = on;
+  Interface::get().led.enabled = true;
 
   return *this;
 }


### PR DESCRIPTION
Implicitly enable LED feedback when a LED pin is set to allow using the LED pin on the ESP32 platform.

Fixes #663 