### PR TITLE
Add option to set retained config to /set topic

### DIFF
--- a/src/SendingPromise.cpp
+++ b/src/SendingPromise.cpp
@@ -7,6 +7,7 @@ SendingPromise::SendingPromise()
 , _property(nullptr)
 , _qos(0)
 , _retained(false)
+, _setRetained(true)
 , _overwriteSetter(false)
 , _range { .isRange = false, .index = 0 } {
 }
@@ -18,6 +19,12 @@ SendingPromise& SendingPromise::setQos(uint8_t qos) {
 
 SendingPromise& SendingPromise::setRetained(bool retained) {
   _retained = retained;
+  return *this;
+}
+
+SendingPromise &SendingPromise::setSetRetained(bool retained)
+{
+  _setRetained = retained;
   return *this;
 }
 
@@ -66,7 +73,7 @@ uint16_t SendingPromise::send(const String& value) {
 
   if (_overwriteSetter) {
     strcat_P(topic, PSTR("/set"));
-    Interface::get().getMqttClient().publish(topic, 1, true, value.c_str());
+    Interface::get().getMqttClient().publish(topic, 1, _setRetained, value.c_str());
   }
 
   delete[] topic;

--- a/src/SendingPromise.hpp
+++ b/src/SendingPromise.hpp
@@ -15,6 +15,7 @@ class SendingPromise {
   SendingPromise();
   SendingPromise& setQos(uint8_t qos);
   SendingPromise& setRetained(bool retained);
+  SendingPromise& setSetRetained(bool retained);
   SendingPromise& overwriteSetter(bool overwrite);
   SendingPromise& setRange(const HomieRange& range);
   SendingPromise& setRange(uint16_t rangeIndex);
@@ -34,6 +35,7 @@ class SendingPromise {
   const String* _property;
   uint8_t _qos;
   bool _retained;
+  bool _setRetained;
   bool _overwriteSetter;
   HomieRange _range;
 };


### PR DESCRIPTION
It's useful when you have a device that doesn't need to restore it's state after a power loss or a reboot.
It's even more useful when you use this library in a device used as a "forwarder" for another device state.

For example I'm using this library in a ESP32 connected to a Controllino Maxi via Serial, so ESP will configure it's name and nodes in setup() and will act as a forwarder of states in loop(), I don't need the state to be restored upon power loss or reboot because Controllino has it's default state at boot, and it can even restore previous state if I want, ESP32 "virtual" state does not matter, controllino will always override it.