### PR TITLE
Fix missing "#if HOMIE_MDNS" clause inside BootNormal::_onWifiGotIp

### DIFF
--- a/src/Homie/Boot/BootNormal.cpp
+++ b/src/Homie/Boot/BootNormal.cpp
@@ -339,7 +339,9 @@ void BootNormal::_onWifiGotIp(WiFiEvent_t event, WiFiEventInfo_t info) {
   Interface::get().event.mask = IPAddress(info.got_ip.ip_info.netmask.addr);
   Interface::get().event.gateway = IPAddress(info.got_ip.ip_info.gw.addr);
   Interface::get().eventHandler(Interface::get().event);
+#if HOMIE_MDNS
   MDNS.begin(Interface::get().getConfig().get().deviceId);
+#endif
 
   _mqttConnect();
 }


### PR DESCRIPTION
There's a missing #if clause, which prevent the homie build for an ESP environment with "-D HOMIE_MDNS=0".

This PR add the missing #if, so that a build with disabled mDNS is possible.
The #if clause is missing in these branches:
 - develop
 - master
 - v3.0

The PR is only for the develop-branch, but cherry-picking for the other branches should be possible.

Regards,
Thomas